### PR TITLE
[ID-230] Nil pointer dereference on missing pubkey in service reg 

### DIFF
--- a/core/auth/auth.go
+++ b/core/auth/auth.go
@@ -991,22 +991,13 @@ func (l *LocalServiceRegLoaderImpl) LoadServices() ([]authservice.ServiceReg, er
 	}
 
 	authRegs := make([]authservice.ServiceReg, len(regs))
-	serviceErrors := map[string]error{}
 	for i, serviceReg := range regs {
 		reg := serviceReg.Registration
-		err = reg.PubKey.LoadKeyFromPem()
-		if err != nil {
-			serviceErrors[reg.ServiceID] = err
-		}
+		reg.PubKey.LoadKeyFromPem()
 		authRegs[i] = reg
 	}
 
-	err = nil
-	if len(serviceErrors) > 0 {
-		err = fmt.Errorf("error loading services: %v", serviceErrors)
-	}
-
-	return authRegs, err
+	return authRegs, nil
 }
 
 //NewLocalServiceRegLoader creates and configures a new LocalServiceRegLoaderImpl instance

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/pkg/errors v0.9.1
 	github.com/pquerna/cachecontrol v0.1.0 // indirect
-	github.com/rokmetro/auth-library v0.1.19
+	github.com/rokmetro/auth-library v0.1.20
 	github.com/rokmetro/logging-library v0.2.2
 	github.com/stretchr/testify v1.6.1
 	github.com/swaggo/http-swagger v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -236,8 +236,8 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.2.2/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
-github.com/rokmetro/auth-library v0.1.19 h1:MWhauHxbG7qp67iAorK/4Fm1re9cEH3D1SzvGh529Ag=
-github.com/rokmetro/auth-library v0.1.19/go.mod h1:KQ9FMCvmZNldprLnLjXZtHwRntn7cD/8sO3JEL+pzG8=
+github.com/rokmetro/auth-library v0.1.20 h1:HM77V2yj0aylMXwO0+Yv/SvGJzgYE7evGeEqgDuzsN0=
+github.com/rokmetro/auth-library v0.1.20/go.mod h1:KQ9FMCvmZNldprLnLjXZtHwRntn7cD/8sO3JEL+pzG8=
 github.com/rokmetro/logging-library v0.2.1/go.mod h1:ye/3piEthlXr//IiPE/IR3K2cRM1y1/VwTY6TlWDGpw=
 github.com/rokmetro/logging-library v0.2.2 h1:N5Qx+ojcAjMaE1eEOF+B1lQBMjZSKZfdWqCDzAWuyCU=
 github.com/rokmetro/logging-library v0.2.2/go.mod h1:ye/3piEthlXr//IiPE/IR3K2cRM1y1/VwTY6TlWDGpw=


### PR DESCRIPTION
Resolves #230

Hi @petyos, I was trying to test the Groups BB integration and I realized that there are issues with service regs that do not contain a pubkey. Not every service needs to have a pubkey registered, so I made changes to the auth-library to resolve this. Please let me know if you see any issues. Thanks!