### PR TITLE
[ID-451] Fix verify credential HTML template loading issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix verify credential HTML template loading issues [#451](https://github.com/rokwire/core-building-block/issues/451)
 
 ## [1.21.0] - 2022-03-16
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ RUN apk --no-cache add tzdata
 COPY --from=builder /core-app/bin/core-building-block /
 
 COPY --from=builder /core-app/driver/web/ui/reset-credential.html /driver/web/ui/reset-credential.html
+COPY --from=builder /core-app/driver/web/ui/error.html /driver/web/ui/error.html
+COPY --from=builder /core-app/driver/web/ui/success.html /driver/web/ui/success.html
 COPY --from=builder /core-app/driver/web/docs/gen/def.yaml /driver/web/docs/gen/def.yaml
 
 COPY --from=builder /core-app/driver/web/authorization_model.conf /driver/web/authorization_model.conf

--- a/driver/web/adapter.go
+++ b/driver/web/adapter.go
@@ -339,6 +339,7 @@ func (we Adapter) serveResponseUI(w http.ResponseWriter, message string, isErr b
 	tmpl, err := template.ParseFiles(file)
 	if err != nil {
 		l.RequestErrorAction(w, logutils.ActionLoad, "page template", nil, err, http.StatusInternalServerError, true)
+		return
 	}
 	data := HTMLResponseTemplate{Message: message}
 	// w.Header().Add("access-control-allow-origin", "*")

--- a/main.go
+++ b/main.go
@@ -55,7 +55,7 @@ func main() {
 	host := envLoader.GetAndLogEnvVar("ROKWIRE_CORE_HOST", true, false)
 
 	// mongoDB adapter
-	mongoDBAuth := envLoader.GetAndLogEnvVar("ROKWIRE_CORE_MONGO_AUTH", true, false)
+	mongoDBAuth := envLoader.GetAndLogEnvVar("ROKWIRE_CORE_MONGO_AUTH", true, true)
 	mongoDBName := envLoader.GetAndLogEnvVar("ROKWIRE_CORE_MONGO_DATABASE", true, false)
 	mongoTimeout := envLoader.GetAndLogEnvVar("ROKWIRE_CORE_MONGO_TIMEOUT", false, false)
 	storageAdapter := storage.NewStorageAdapter(mongoDBAuth, mongoDBName, mongoTimeout, logger)


### PR DESCRIPTION
Resolves #451

Hi @petyos, unfortunately I forgot to copy the new HTML template files to the Docker container so the version currently on dev throws an error when loading these pages. I tested this out in a local Docker instance and it looks like it is working as expected now. Please let me know if you see any other issues. Thanks!