### PR TITLE
[#727] Set up privacy settings for account directory data visibility

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -316,7 +316,7 @@
         "filename": "driver\\web\\docs\\gen\\gen_types.go",
         "hashed_secret": "c9739eab2dfa093cc0e450bf0ea81a43ae67b581",
         "is_verified": false,
-        "line_number": 1868
+        "line_number": 1869
       }
     ],
     "driver\\web\\docs\\resources\\admin\\auth\\login.yaml": [
@@ -347,5 +347,5 @@
       }
     ]
   },
-  "generated_at": "2024-11-20T06:40:43Z"
+  "generated_at": "2024-11-20T06:46:20Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -136,216 +136,216 @@
         "line_number": 37
       }
     ],
-    "core/app_shared.go": [
+    "core\\app_shared.go": [
       {
         "type": "Secret Keyword",
-        "filename": "core/app_shared.go",
+        "filename": "core\\app_shared.go",
         "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
         "is_verified": false,
         "line_number": 41
       }
     ],
-    "core/auth/apis.go": [
+    "core\\auth\\apis.go": [
       {
         "type": "Secret Keyword",
-        "filename": "core/auth/apis.go",
+        "filename": "core\\auth\\apis.go",
         "hashed_secret": "394e3412459f79523e12e1fa95a4cf141ccff122",
         "is_verified": false,
         "line_number": 2231
       }
     ],
-    "core/auth/auth.go": [
+    "core\\auth\\auth.go": [
       {
         "type": "Secret Keyword",
-        "filename": "core/auth/auth.go",
+        "filename": "core\\auth\\auth.go",
         "hashed_secret": "58f3388441fbce0e48aef2bf74413a6f43f6dc70",
         "is_verified": false,
         "line_number": 1057
       },
       {
         "type": "Secret Keyword",
-        "filename": "core/auth/auth.go",
+        "filename": "core\\auth\\auth.go",
         "hashed_secret": "94a7f0195bbbd2260c4e4d02b6348fbcd90b2b30",
         "is_verified": false,
         "line_number": 2782
       }
     ],
-    "core/auth/auth_type_email.go": [
+    "core\\auth\\auth_type_email.go": [
       {
         "type": "Secret Keyword",
-        "filename": "core/auth/auth_type_email.go",
+        "filename": "core\\auth\\auth_type_email.go",
         "hashed_secret": "f3f2fb17a3bf9f307cb6e79b61b9d4baf07dd681",
         "is_verified": false,
         "line_number": 75
       },
       {
         "type": "Secret Keyword",
-        "filename": "core/auth/auth_type_email.go",
+        "filename": "core\\auth\\auth_type_email.go",
         "hashed_secret": "fe70d8c51780596c0b3399573122bba943a461da",
         "is_verified": false,
         "line_number": 76
       },
       {
         "type": "Secret Keyword",
-        "filename": "core/auth/auth_type_email.go",
+        "filename": "core\\auth\\auth_type_email.go",
         "hashed_secret": "06354d205ab5a3b6c7ad2333c58f1ddc810c97ba",
         "is_verified": false,
         "line_number": 87
       },
       {
         "type": "Secret Keyword",
-        "filename": "core/auth/auth_type_email.go",
+        "filename": "core\\auth\\auth_type_email.go",
         "hashed_secret": "7cbe6dcf7274355d223e3174e4d8a7ffb55a9227",
         "is_verified": false,
         "line_number": 156
       },
       {
         "type": "Secret Keyword",
-        "filename": "core/auth/auth_type_email.go",
+        "filename": "core\\auth\\auth_type_email.go",
         "hashed_secret": "69411040443be576ce64fc793269d7c26dd0866a",
         "is_verified": false,
         "line_number": 253
       },
       {
         "type": "Secret Keyword",
-        "filename": "core/auth/auth_type_email.go",
+        "filename": "core\\auth\\auth_type_email.go",
         "hashed_secret": "cba104f0870345d3ec99d55c06441bdce9fcf584",
         "is_verified": false,
         "line_number": 390
       },
       {
         "type": "Secret Keyword",
-        "filename": "core/auth/auth_type_email.go",
+        "filename": "core\\auth\\auth_type_email.go",
         "hashed_secret": "c74f3640d83fd19d941a4f44b28fbd9e57f59eef",
         "is_verified": false,
         "line_number": 391
       }
     ],
-    "core/auth/auth_type_oidc.go": [
+    "core\\auth\\auth_type_oidc.go": [
       {
         "type": "Secret Keyword",
-        "filename": "core/auth/auth_type_oidc.go",
+        "filename": "core\\auth\\auth_type_oidc.go",
         "hashed_secret": "0ade4f3edccc8888bef404fe6b3c92c13cdfad6b",
         "is_verified": false,
         "line_number": 392
       }
     ],
-    "core/auth/auth_type_username.go": [
+    "core\\auth\\auth_type_username.go": [
       {
         "type": "Secret Keyword",
-        "filename": "core/auth/auth_type_username.go",
+        "filename": "core\\auth\\auth_type_username.go",
         "hashed_secret": "86f4f81d8dcd41f5f695464a3bba658467957bb3",
         "is_verified": false,
         "line_number": 64
       },
       {
         "type": "Secret Keyword",
-        "filename": "core/auth/auth_type_username.go",
+        "filename": "core\\auth\\auth_type_username.go",
         "hashed_secret": "d6f3638bf6ffed24773951f1a48460efa6766362",
         "is_verified": false,
         "line_number": 65
       },
       {
         "type": "Secret Keyword",
-        "filename": "core/auth/auth_type_username.go",
+        "filename": "core\\auth\\auth_type_username.go",
         "hashed_secret": "06354d205ab5a3b6c7ad2333c58f1ddc810c97ba",
         "is_verified": false,
         "line_number": 77
       },
       {
         "type": "Secret Keyword",
-        "filename": "core/auth/auth_type_username.go",
+        "filename": "core\\auth\\auth_type_username.go",
         "hashed_secret": "7cbe6dcf7274355d223e3174e4d8a7ffb55a9227",
         "is_verified": false,
         "line_number": 179
       },
       {
         "type": "Secret Keyword",
-        "filename": "core/auth/auth_type_username.go",
+        "filename": "core\\auth\\auth_type_username.go",
         "hashed_secret": "cba104f0870345d3ec99d55c06441bdce9fcf584",
         "is_verified": false,
         "line_number": 215
       },
       {
         "type": "Secret Keyword",
-        "filename": "core/auth/auth_type_username.go",
+        "filename": "core\\auth\\auth_type_username.go",
         "hashed_secret": "c74f3640d83fd19d941a4f44b28fbd9e57f59eef",
         "is_verified": false,
         "line_number": 216
       }
     ],
-    "core/auth/service_static_token.go": [
+    "core\\auth\\service_static_token.go": [
       {
         "type": "Secret Keyword",
-        "filename": "core/auth/service_static_token.go",
+        "filename": "core\\auth\\service_static_token.go",
         "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
         "is_verified": false,
         "line_number": 78
       }
     ],
-    "driven/storage/database.go": [
+    "driven\\storage\\database.go": [
       {
         "type": "Secret Keyword",
-        "filename": "driven/storage/database.go",
+        "filename": "driven\\storage\\database.go",
         "hashed_secret": "6547f385c6d867e20f8217018a4d468a7d67d638",
         "is_verified": false,
         "line_number": 236
       }
     ],
-    "driver/web/apis_system.go": [
+    "driver\\web\\apis_system.go": [
       {
         "type": "Secret Keyword",
-        "filename": "driver/web/apis_system.go",
+        "filename": "driver\\web\\apis_system.go",
         "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
         "is_verified": false,
         "line_number": 637
       }
     ],
-    "driver/web/docs/gen/def.yaml": [
+    "driver\\web\\docs\\gen\\def.yaml": [
       {
         "type": "Secret Keyword",
-        "filename": "driver/web/docs/gen/def.yaml",
+        "filename": "driver\\web\\docs\\gen\\def.yaml",
         "hashed_secret": "448ed7416fce2cb66c285d182b1ba3df1e90016d",
         "is_verified": false,
         "line_number": 55
       }
     ],
-    "driver/web/docs/gen/gen_types.go": [
+    "driver\\web\\docs\\gen\\gen_types.go": [
       {
         "type": "Secret Keyword",
-        "filename": "driver/web/docs/gen/gen_types.go",
+        "filename": "driver\\web\\docs\\gen\\gen_types.go",
         "hashed_secret": "c9739eab2dfa093cc0e450bf0ea81a43ae67b581",
         "is_verified": false,
-        "line_number": 1861
+        "line_number": 1868
       }
     ],
-    "driver/web/docs/resources/admin/auth/login.yaml": [
+    "driver\\web\\docs\\resources\\admin\\auth\\login.yaml": [
       {
         "type": "Secret Keyword",
-        "filename": "driver/web/docs/resources/admin/auth/login.yaml",
+        "filename": "driver\\web\\docs\\resources\\admin\\auth\\login.yaml",
         "hashed_secret": "448ed7416fce2cb66c285d182b1ba3df1e90016d",
         "is_verified": false,
         "line_number": 26
       }
     ],
-    "driver/web/docs/resources/services/auth/account/auth-type/link.yaml": [
+    "driver\\web\\docs\\resources\\services\\auth\\account\\auth-type\\link.yaml": [
       {
         "type": "Secret Keyword",
-        "filename": "driver/web/docs/resources/services/auth/account/auth-type/link.yaml",
+        "filename": "driver\\web\\docs\\resources\\services\\auth\\account\\auth-type\\link.yaml",
         "hashed_secret": "448ed7416fce2cb66c285d182b1ba3df1e90016d",
         "is_verified": false,
         "line_number": 26
       }
     ],
-    "driver/web/docs/resources/services/auth/login.yaml": [
+    "driver\\web\\docs\\resources\\services\\auth\\login.yaml": [
       {
         "type": "Secret Keyword",
-        "filename": "driver/web/docs/resources/services/auth/login.yaml",
+        "filename": "driver\\web\\docs\\resources\\services\\auth\\login.yaml",
         "hashed_secret": "448ed7416fce2cb66c285d182b1ba3df1e90016d",
         "is_verified": false,
         "line_number": 24
       }
     ]
   },
-  "generated_at": "2024-10-21T07:45:37Z"
+  "generated_at": "2024-11-20T06:40:43Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -316,7 +316,7 @@
         "filename": "driver\\web\\docs\\gen\\gen_types.go",
         "hashed_secret": "c9739eab2dfa093cc0e450bf0ea81a43ae67b581",
         "is_verified": false,
-        "line_number": 1875
+        "line_number": 1876
       }
     ],
     "driver\\web\\docs\\resources\\admin\\auth\\login.yaml": [
@@ -347,5 +347,5 @@
       }
     ]
   },
-  "generated_at": "2024-11-25T23:02:14Z"
+  "generated_at": "2024-11-27T23:13:12Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -316,7 +316,7 @@
         "filename": "driver\\web\\docs\\gen\\gen_types.go",
         "hashed_secret": "c9739eab2dfa093cc0e450bf0ea81a43ae67b581",
         "is_verified": false,
-        "line_number": 1869
+        "line_number": 1875
       }
     ],
     "driver\\web\\docs\\resources\\admin\\auth\\login.yaml": [
@@ -347,5 +347,5 @@
       }
     ]
   },
-  "generated_at": "2024-11-20T06:46:20Z"
+  "generated_at": "2024-11-25T23:02:14Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Set up privacy settings for account directory data visibility [#727](https://github.com/rokwire/core-building-block/issues/727)
+
 ## [1.43.0] - 2024-10-21
 ### Added
 - Get the account ids with FERPA filed false [#724](https://github.com/rokwire/core-building-block/issues/724)

--- a/core/apis.go
+++ b/core/apis.go
@@ -307,6 +307,10 @@ func (s *servicesImpl) SerGetProfile(cOrgID string, cAppID string, accountID str
 	return s.app.serGetProfile(cOrgID, cAppID, accountID)
 }
 
+func (s *servicesImpl) SerGetAccountPrivacy(cOrgID string, cAppID string, accountID string) (*model.Privacy, error) {
+	return s.app.serGetPrivacy(cOrgID, cAppID, accountID)
+}
+
 func (s *servicesImpl) SerGetPreferences(cOrgID string, cAppID string, accountID string) (map[string]interface{}, error) {
 	return s.app.serGetPreferences(cOrgID, cAppID, accountID)
 }

--- a/core/app_services.go
+++ b/core/app_services.go
@@ -150,17 +150,7 @@ func (app *application) serGetPublicAccounts(appID string, orgID string, limit i
 		return nil, errors.WrapErrorAction(logutils.ActionFind, model.TypeAccount, nil, err)
 	}
 
-	publicAccounts := make([]model.PublicAccount, 0)
-	for _, account := range accounts {
-		publicAccount, err := account.GetPublicAccount(false) //TODO: get actual connection status
-		if err != nil {
-			app.logger.Errorf("error getting public account: %v", err)
-			continue
-		}
-		publicAccounts = append(publicAccounts, *publicAccount)
-	}
-
-	return publicAccounts, nil
+	return accounts, nil
 }
 
 func (app *application) serAddFollow(follow model.Follow) error {

--- a/core/app_services.go
+++ b/core/app_services.go
@@ -17,8 +17,6 @@ package core
 import (
 	"core-building-block/core/model"
 	"core-building-block/driven/storage"
-	"fmt"
-	"reflect"
 	"time"
 
 	"github.com/google/uuid"
@@ -152,36 +150,14 @@ func (app *application) serGetPublicAccounts(appID string, orgID string, limit i
 		return nil, errors.WrapErrorAction(logutils.ActionFind, model.TypeAccount, nil, err)
 	}
 
-	publicAccounts := make([]model.PublicAccount, len(accounts))
+	publicAccounts := make([]model.PublicAccount, 0)
 	for _, account := range accounts {
-		//TODO: use reflect package and account.Privacy.FieldVisbility to remove account fields as specified
-		// v := reflect.ValueOf(account)
-		t := reflect.TypeOf(account)
-		publicAccount := model.PublicAccount{}
-
-		for i := 0; i < t.NumField(); i++ {
-			field := t.Field(i)
-			tag := field.Tag.Get("json")
-			if field.Name == "Profile" {
-				profileType := reflect.TypeOf(field)
-				profileValue := reflect.ValueOf(field)
-				for j := 0; j < profileType.NumField(); j++ {
-					profileField := profileType.Field(j)
-					profileFieldValue := profileValue.Field(j)
-					profileFieldTag := profileField.Tag.Get("json")
-					visible, err := account.Privacy.IsFieldVisible(fmt.Sprintf("%s.%s", tag, profileFieldTag), false) //TODO: use actual connection status
-					if err != nil {
-						//TODO: return error
-					}
-					if visible && profileFieldValue.CanAddr() {
-						publicAccountValue := reflect.ValueOf(publicAccount)
-						publicAccountValue.FieldByName(profileField.Name).Set(profileFieldValue.Addr())
-					}
-				}
-			} else if field.Name == "AuthTypes" {
-
-			}
+		publicAccount, err := account.GetPublicAccount(false) //TODO: get actual connection status
+		if err != nil {
+			app.logger.Errorf("error getting public account: %v", err)
+			continue
 		}
+		publicAccounts = append(publicAccounts, *publicAccount)
 	}
 
 	return publicAccounts, nil

--- a/core/app_services.go
+++ b/core/app_services.go
@@ -37,6 +37,18 @@ func (app *application) serGetProfile(cOrgID string, cAppID string, accountID st
 	return &profile, nil
 }
 
+func (app *application) serGetPrivacy(cOrgID string, cAppID string, accountID string) (*model.Privacy, error) {
+	//find the account
+	account, err := app.storage.FindAccountByIDV2(nil, cOrgID, cAppID, accountID)
+	if err != nil {
+		return nil, errors.WrapErrorAction(logutils.ActionFind, model.TypeAccount, nil, err)
+	}
+
+	//get the privacy for the account
+	privacy := account.Privacy
+	return &privacy, nil
+}
+
 func (app *application) serGetAccount(cOrgID string, cAppID string, accountID string) (*model.Account, error) {
 	return app.getAccountV2(nil, cOrgID, cAppID, accountID)
 }

--- a/core/auth/auth.go
+++ b/core/auth/auth.go
@@ -480,7 +480,7 @@ func (a *Auth) applyOrgSignUpExternal(context storage.TransactionContext, authTy
 
 	var identityBBProfile *model.Profile
 	if identityProviderSetting.IdentityBBBaseURL != "" {
-		identityBBProfile, err = a.identityBB.GetUserProfile(identityProviderSetting.IdentityBBBaseURL, externalUser, externalCreds, l)
+		identityBBProfile, err = a.identityBB.GetUserProfile(identityProviderSetting.IdentityBBBaseURL, externalUser, externalCreds, identityProviderSetting.IdentityBBProfileFields, l)
 		if err != nil {
 			l.WarnError(logutils.MessageAction(logutils.StatusError, "syncing", "identity bb data", nil), err)
 		}
@@ -644,7 +644,7 @@ func (a *Auth) updateExternalUserIfNeeded(accountAuthType model.AccountAuthType,
 
 	var identityBBProfile *model.Profile
 	if identityProviderSetting.IdentityBBBaseURL != "" {
-		identityBBProfile, err = a.identityBB.GetUserProfile(identityProviderSetting.IdentityBBBaseURL, externalUser, externalCreds, l)
+		identityBBProfile, err = a.identityBB.GetUserProfile(identityProviderSetting.IdentityBBBaseURL, externalUser, externalCreds, identityProviderSetting.IdentityBBProfileFields, l)
 		if err != nil {
 			l.WarnError(logutils.MessageAction(logutils.StatusError, "syncing", "identity bb data", nil), err)
 		}

--- a/core/auth/interfaces.go
+++ b/core/auth/interfaces.go
@@ -607,7 +607,7 @@ type ProfileBuildingBlock interface {
 
 // IdentityBuildingBlock is used by auth to communicate with the identity building block.
 type IdentityBuildingBlock interface {
-	GetUserProfile(baseURL string, externalUser model.ExternalSystemUser, externalAccessToken string, l *logs.Log) (*model.Profile, error)
+	GetUserProfile(baseURL string, externalUser model.ExternalSystemUser, externalAccessToken string, profileFields map[string]string, l *logs.Log) (*model.Profile, error)
 }
 
 // Emailer is used by core to send emails

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -173,7 +173,7 @@ type Storage interface {
 	FindAccounts(context storage.TransactionContext, limit *int, offset *int, appID string, orgID string, accountID *string, firstName *string, lastName *string, authType *string,
 		authTypeIdentifier *string, anonymous *bool, hasPermissions *bool, permissions []string, roleIDs []string, groupIDs []string) ([]model.Account, error)
 	FindPublicAccounts(context storage.TransactionContext, appID string, orgID string, limit *int, offset *int,
-		search *string, firstName *string, lastName *string, username *string, followingID *string, followerID *string, userID string) ([]model.PublicAccount, error)
+		search *string, firstName *string, lastName *string, username *string, followingID *string, followerID *string, userID string) ([]model.Account, error)
 	FindAccountsByParams(searchParams map[string]interface{}, appID string, orgID string, limit int, offset int, allAccess bool, approvedKeys []string) ([]map[string]interface{}, error)
 	CountAccountsByParams(searchParams map[string]interface{}, appID string, orgID string) (int64, error)
 	FindAccountsByAccountID(context storage.TransactionContext, appID string, orgID string, accountIDs []string) ([]model.Account, error)

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -27,6 +27,7 @@ import (
 type Services interface {
 	SerGetAccount(cOrgID string, cAppID string, accountID string) (*model.Account, error)
 	SerGetProfile(cOrgID string, cAppID string, accountID string) (*model.Profile, error)
+	SerGetAccountPrivacy(cOrgID string, cAppID string, accountID string) (*model.Privacy, error)
 	SerGetPreferences(cOrgID string, cAppID string, accountID string) (map[string]interface{}, error)
 	SerGetAccountSystemConfigs(cOrgID string, cAppID string, accountID string) (map[string]interface{}, error)
 	SerUpdateAccountPreferences(id string, appID string, orgID string, anonymous bool, preferences map[string]interface{}, l *logs.Log) (bool, error)

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -173,7 +173,7 @@ type Storage interface {
 	FindAccounts(context storage.TransactionContext, limit *int, offset *int, appID string, orgID string, accountID *string, firstName *string, lastName *string, authType *string,
 		authTypeIdentifier *string, anonymous *bool, hasPermissions *bool, permissions []string, roleIDs []string, groupIDs []string) ([]model.Account, error)
 	FindPublicAccounts(context storage.TransactionContext, appID string, orgID string, limit *int, offset *int,
-		search *string, firstName *string, lastName *string, username *string, followingID *string, followerID *string, userID string) ([]model.Account, error)
+		search *string, firstName *string, lastName *string, username *string, followingID *string, followerID *string, userID string) ([]model.PublicAccount, error)
 	FindAccountsByParams(searchParams map[string]interface{}, appID string, orgID string, limit int, offset int, allAccess bool, approvedKeys []string) ([]map[string]interface{}, error)
 	CountAccountsByParams(searchParams map[string]interface{}, appID string, orgID string) (int64, error)
 	FindAccountsByAccountID(context storage.TransactionContext, appID string, orgID string, accountIDs []string) ([]model.Account, error)

--- a/core/mocks/Storage.go
+++ b/core/mocks/Storage.go
@@ -1448,23 +1448,23 @@ func (_m *Storage) FindPermissionsByServiceIDs(serviceIDs []string) ([]model.Per
 }
 
 // FindPublicAccounts provides a mock function with given fields: context, appID, orgID, limit, offset, search, firstName, lastName, username, followingID, followerID, userID
-func (_m *Storage) FindPublicAccounts(context storage.TransactionContext, appID string, orgID string, limit *int, offset *int, search *string, firstName *string, lastName *string, username *string, followingID *string, followerID *string, userID string) ([]model.PublicAccount, error) {
+func (_m *Storage) FindPublicAccounts(context storage.TransactionContext, appID string, orgID string, limit *int, offset *int, search *string, firstName *string, lastName *string, username *string, followingID *string, followerID *string, userID string) ([]model.Account, error) {
 	ret := _m.Called(context, appID, orgID, limit, offset, search, firstName, lastName, username, followingID, followerID, userID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for FindPublicAccounts")
 	}
 
-	var r0 []model.PublicAccount
+	var r0 []model.Account
 	var r1 error
-	if rf, ok := ret.Get(0).(func(storage.TransactionContext, string, string, *int, *int, *string, *string, *string, *string, *string, *string, string) ([]model.PublicAccount, error)); ok {
+	if rf, ok := ret.Get(0).(func(storage.TransactionContext, string, string, *int, *int, *string, *string, *string, *string, *string, *string, string) ([]model.Account, error)); ok {
 		return rf(context, appID, orgID, limit, offset, search, firstName, lastName, username, followingID, followerID, userID)
 	}
-	if rf, ok := ret.Get(0).(func(storage.TransactionContext, string, string, *int, *int, *string, *string, *string, *string, *string, *string, string) []model.PublicAccount); ok {
+	if rf, ok := ret.Get(0).(func(storage.TransactionContext, string, string, *int, *int, *string, *string, *string, *string, *string, *string, string) []model.Account); ok {
 		r0 = rf(context, appID, orgID, limit, offset, search, firstName, lastName, username, followingID, followerID, userID)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]model.PublicAccount)
+			r0 = ret.Get(0).([]model.Account)
 		}
 	}
 

--- a/core/mocks/Storage.go
+++ b/core/mocks/Storage.go
@@ -1448,23 +1448,23 @@ func (_m *Storage) FindPermissionsByServiceIDs(serviceIDs []string) ([]model.Per
 }
 
 // FindPublicAccounts provides a mock function with given fields: context, appID, orgID, limit, offset, search, firstName, lastName, username, followingID, followerID, userID
-func (_m *Storage) FindPublicAccounts(context storage.TransactionContext, appID string, orgID string, limit *int, offset *int, search *string, firstName *string, lastName *string, username *string, followingID *string, followerID *string, userID string) ([]model.Account, error) {
+func (_m *Storage) FindPublicAccounts(context storage.TransactionContext, appID string, orgID string, limit *int, offset *int, search *string, firstName *string, lastName *string, username *string, followingID *string, followerID *string, userID string) ([]model.PublicAccount, error) {
 	ret := _m.Called(context, appID, orgID, limit, offset, search, firstName, lastName, username, followingID, followerID, userID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for FindPublicAccounts")
 	}
 
-	var r0 []model.Account
+	var r0 []model.PublicAccount
 	var r1 error
-	if rf, ok := ret.Get(0).(func(storage.TransactionContext, string, string, *int, *int, *string, *string, *string, *string, *string, *string, string) ([]model.Account, error)); ok {
+	if rf, ok := ret.Get(0).(func(storage.TransactionContext, string, string, *int, *int, *string, *string, *string, *string, *string, *string, string) ([]model.PublicAccount, error)); ok {
 		return rf(context, appID, orgID, limit, offset, search, firstName, lastName, username, followingID, followerID, userID)
 	}
-	if rf, ok := ret.Get(0).(func(storage.TransactionContext, string, string, *int, *int, *string, *string, *string, *string, *string, *string, string) []model.Account); ok {
+	if rf, ok := ret.Get(0).(func(storage.TransactionContext, string, string, *int, *int, *string, *string, *string, *string, *string, *string, string) []model.PublicAccount); ok {
 		r0 = rf(context, appID, orgID, limit, offset, search, firstName, lastName, username, followingID, followerID, userID)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]model.Account)
+			r0 = ret.Get(0).([]model.PublicAccount)
 		}
 	}
 

--- a/core/model/application.go
+++ b/core/model/application.go
@@ -384,8 +384,9 @@ type IdentityProviderSetting struct {
 
 	UserSpecificFields []string `bson:"user_specific_fields"`
 
-	AlwaysSyncProfile bool   `bson:"always_sync_profile"` // if true, profile data will be overwritten with data from external user on each login/refresh
-	IdentityBBBaseURL string `bson:"identity_bb_base_url"`
+	AlwaysSyncProfile       bool              `bson:"always_sync_profile"` // if true, profile data will be overwritten with data from external user on each login/refresh
+	IdentityBBBaseURL       string            `bson:"identity_bb_base_url"`
+	IdentityBBProfileFields map[string]string `bson:"identity_bb_profile_fields"` // a map from paths into the data returned by the Identity BB to keys in Profile.UnstructuredProperties
 
 	Roles  map[string]string `bson:"roles"`  //map[identity_provider_role]app_role_id
 	Groups map[string]string `bson:"groups"` //map[identity_provider_group]app_group_id

--- a/core/model/user.go
+++ b/core/model/user.go
@@ -79,6 +79,7 @@ type Privacy struct {
 	FieldVisibility map[string]interface{} `json:"field_visibility" bson:"field_visibility"`
 }
 
+// GetFieldVisibility determines the privacy setting for the account data at path
 func (p *Privacy) GetFieldVisibility(path string, visibilityMap map[string]interface{}) (string, error) {
 	if visibilityMap == nil {
 		visibilityMap = p.FieldVisibility
@@ -100,6 +101,7 @@ func (p *Privacy) GetFieldVisibility(path string, visibilityMap map[string]inter
 	return visibility, nil
 }
 
+// IsFieldVisible determines whether the account data at path should be visible to the requesting user
 func (p *Privacy) IsFieldVisible(path string, isConnection bool) (bool, error) {
 	visibility, err := p.GetFieldVisibility(path, nil)
 	if err != nil {

--- a/core/model/user.go
+++ b/core/model/user.go
@@ -805,16 +805,19 @@ type MFAType struct {
 type Profile struct {
 	ID string `json:"id"`
 
-	PhotoURL  string `json:"photo_url"`
-	FirstName string `json:"first_name"`
-	LastName  string `json:"last_name"`
-	Email     string `json:"email"`
-	Phone     string `json:"phone"`
-	BirthYear int16  `json:"birth_year"`
-	Address   string `json:"address"`
-	ZipCode   string `json:"zip_code"`
-	State     string `json:"state"`
-	Country   string `json:"country"`
+	PhotoURL         string `json:"photo_url"`
+	PronunciationURL string `json:"pronunciation_url"`
+	Pronouns         string `json:"pronouns"`
+	FirstName        string `json:"first_name"`
+	LastName         string `json:"last_name"`
+	Email            string `json:"email"`
+	Phone            string `json:"phone"`
+	BirthYear        int16  `json:"birth_year"`
+	Address          string `json:"address"`
+	ZipCode          string `json:"zip_code"`
+	State            string `json:"state"`
+	Country          string `json:"country"`
+	Website          string `json:"website"`
 
 	UnstructuredProperties map[string]interface{} `json:"unstructured_properties"`
 

--- a/core/model/user.go
+++ b/core/model/user.go
@@ -71,6 +71,9 @@ const (
 	//AccountFieldExternalIDs is the reflect name of the external IDs field in Account
 	AccountFieldExternalIDs string = "ExternalIDs"
 
+	//ProfileFieldUnstructuredProperties is the reflect name of the unstructured properties field in Profile
+	ProfileFieldUnstructuredProperties string = "UnstructuredProperties"
+
 	//VisibilityPublic indicates a field is visible to all other app org members
 	VisibilityPublic string = "public"
 	//VisibilityConnections indicates a field is visible to user-connected app org members
@@ -478,147 +481,44 @@ func (a *Account) GetPublicProfile(isConnection bool) (*PublicProfile, error) {
 		return nil, errors.ErrorData(logutils.StatusMissing, TypeAccount, nil)
 	}
 
+	publicProfile := PublicProfile{}
 	accountType := reflect.TypeOf(a).Elem()
 	profileField, _ := accountType.FieldByName(AccountFieldProfile)
-	profileTag := profileField.Tag.Get("json")
-	profileType := reflect.TypeOf(a.Profile)
-
-	var photoURL *string
-	if a.Profile.PhotoURL != "" {
-		photoURLField, _ := profileType.FieldByName("PhotoURL")
-		photoURLTag := photoURLField.Tag.Get("json")
-		visible, err := a.Privacy.IsFieldVisible(fmt.Sprintf("%s.%s", profileTag, photoURLTag), isConnection)
-		if err != nil {
-			return nil, errors.WrapErrorAction(logutils.ActionGet, "visibility", logutils.StringArgs(photoURLTag), err)
-		}
-		if visible {
-			photoURL = &a.Profile.PhotoURL
-		}
-	}
-	var firstName *string
-	if a.Profile.FirstName != "" {
-		firstNameField, _ := profileType.FieldByName("FirstName")
-		firstNameTag := firstNameField.Tag.Get("json")
-		visible, err := a.Privacy.IsFieldVisible(fmt.Sprintf("%s.%s", profileTag, firstNameTag), isConnection)
-		if err != nil {
-			return nil, errors.WrapErrorAction(logutils.ActionGet, "visibility", logutils.StringArgs(firstNameTag), err)
-		}
-		if visible {
-			firstName = &a.Profile.FirstName
-		}
-	}
-	var lastName *string
-	if a.Profile.LastName != "" {
-		lastNameField, _ := profileType.FieldByName("LastName")
-		lastNameTag := lastNameField.Tag.Get("json")
-		visible, err := a.Privacy.IsFieldVisible(fmt.Sprintf("%s.%s", profileTag, lastNameTag), isConnection)
-		if err != nil {
-			return nil, errors.WrapErrorAction(logutils.ActionGet, "visibility", logutils.StringArgs(lastNameTag), err)
-		}
-		if visible {
-			lastName = &a.Profile.LastName
-		}
-	}
-	var email *string
-	if a.Profile.Email != "" {
-		emailField, _ := profileType.FieldByName("Email")
-		emailTag := emailField.Tag.Get("json")
-		visible, err := a.Privacy.IsFieldVisible(fmt.Sprintf("%s.%s", profileTag, emailTag), isConnection)
-		if err != nil {
-			return nil, errors.WrapErrorAction(logutils.ActionGet, "visibility", logutils.StringArgs(emailTag), err)
-		}
-		if visible {
-			email = &a.Profile.Email
-		}
-	}
-	var phone *string
-	if a.Profile.Phone != "" {
-		phoneField, _ := profileType.FieldByName("Phone")
-		phoneTag := phoneField.Tag.Get("json")
-		visible, err := a.Privacy.IsFieldVisible(fmt.Sprintf("%s.%s", profileTag, phoneTag), isConnection)
-		if err != nil {
-			return nil, errors.WrapErrorAction(logutils.ActionGet, "visibility", logutils.StringArgs(phoneTag), err)
-		}
-		if visible {
-			phone = &a.Profile.Phone
-		}
-	}
-	var birthYear *int16
-	if a.Profile.BirthYear != 0 {
-		birthYearField, _ := profileType.FieldByName("BirthYear")
-		birthYearTag := birthYearField.Tag.Get("json")
-		visible, err := a.Privacy.IsFieldVisible(fmt.Sprintf("%s.%s", profileTag, birthYearTag), isConnection)
-		if err != nil {
-			return nil, errors.WrapErrorAction(logutils.ActionGet, "visibility", logutils.StringArgs(birthYearTag), err)
-		}
-		if visible {
-			birthYear = &a.Profile.BirthYear
-		}
-	}
-	var address *string
-	if a.Profile.Address != "" {
-		addressField, _ := profileType.FieldByName("Address")
-		addressTag := addressField.Tag.Get("json")
-		visible, err := a.Privacy.IsFieldVisible(fmt.Sprintf("%s.%s", profileTag, addressTag), isConnection)
-		if err != nil {
-			return nil, errors.WrapErrorAction(logutils.ActionGet, "visibility", logutils.StringArgs(addressTag), err)
-		}
-		if visible {
-			address = &a.Profile.Address
-		}
-	}
-	var zipCode *string
-	if a.Profile.ZipCode != "" {
-		zipCodeField, _ := profileType.FieldByName("ZipCode")
-		zipCodeTag := zipCodeField.Tag.Get("json")
-		visible, err := a.Privacy.IsFieldVisible(fmt.Sprintf("%s.%s", profileTag, zipCodeTag), isConnection)
-		if err != nil {
-			return nil, errors.WrapErrorAction(logutils.ActionGet, "visibility", logutils.StringArgs(zipCodeTag), err)
-		}
-		if visible {
-			zipCode = &a.Profile.ZipCode
-		}
-	}
-	var state *string
-	if a.Profile.State != "" {
-		stateField, _ := profileType.FieldByName("State")
-		stateTag := stateField.Tag.Get("json")
-		visible, err := a.Privacy.IsFieldVisible(fmt.Sprintf("%s.%s", profileTag, stateTag), isConnection)
-		if err != nil {
-			return nil, errors.WrapErrorAction(logutils.ActionGet, "visibility", logutils.StringArgs(stateTag), err)
-		}
-		if visible {
-			state = &a.Profile.State
-		}
-	}
-	var country *string
-	if a.Profile.Country != "" {
-		countryField, _ := profileType.FieldByName("Country")
-		countryTag := countryField.Tag.Get("json")
-		visible, err := a.Privacy.IsFieldVisible(fmt.Sprintf("%s.%s", profileTag, countryTag), isConnection)
-		if err != nil {
-			return nil, errors.WrapErrorAction(logutils.ActionGet, "visibility", logutils.StringArgs(countryTag), err)
-		}
-		if visible {
-			country = &a.Profile.Country
-		}
-	}
-	var unstructuredProperties map[string]interface{}
-	if len(a.Profile.UnstructuredProperties) > 0 {
-		unstructuredPropertiesField, _ := profileType.FieldByName("UnstructuredProperties")
-		unstructuredPropertiesTag := unstructuredPropertiesField.Tag.Get("json")
-		visible, err := a.Privacy.IsFieldVisible(fmt.Sprintf("%s.%s", profileTag, unstructuredPropertiesTag), isConnection)
-		if err != nil {
-			return nil, errors.WrapErrorAction(logutils.ActionGet, "visibility", logutils.StringArgs(unstructuredPropertiesTag), err)
-		}
-		if visible {
-			unstructuredProperties = a.Profile.UnstructuredProperties
+	profileValue := reflect.ValueOf(&a.Profile).Elem()
+	for i := 0; i < profileField.Type.NumField(); i++ {
+		field := profileField.Type.Field(i)
+		fieldValue := profileValue.Field(i)
+		fieldTag := field.Tag.Get("json")
+		visibilityPath := fmt.Sprintf("%s.%s", profileField.Tag.Get("json"), fieldTag)
+		if field.Name == ProfileFieldUnstructuredProperties {
+			for k, v := range a.Profile.UnstructuredProperties {
+				visible, err := a.Privacy.IsFieldVisible(fmt.Sprintf("%s.%s", visibilityPath, k), isConnection)
+				if err != nil {
+					return nil, errors.WrapErrorAction(logutils.ActionGet, "visibility", logutils.StringArgs(fmt.Sprintf("%s.%s", fieldTag, k)), err)
+				}
+				if visible {
+					if publicProfile.UnstructuredProperties == nil {
+						publicProfile.UnstructuredProperties = make(map[string]interface{})
+					}
+					publicProfile.UnstructuredProperties[k] = v
+				}
+			}
+		} else {
+			publicProfileField := reflect.ValueOf(&publicProfile).Elem().FieldByName(field.Name) // get matching public profile field
+			if !publicProfileField.IsValid() {
+				continue // if there is no matching public profile field, go to next
+			}
+			visible, err := a.Privacy.IsFieldVisible(visibilityPath, isConnection)
+			if err != nil {
+				return nil, errors.WrapErrorAction(logutils.ActionGet, "visibility", logutils.StringArgs(fieldTag), err)
+			}
+			if visible && fieldValue.CanAddr() && publicProfileField.CanSet() {
+				publicProfileField.Set(fieldValue.Addr())
+			}
 		}
 	}
 
-	return &PublicProfile{PhotoURL: photoURL, FirstName: firstName, LastName: lastName,
-		Email: email, Phone: phone, BirthYear: birthYear, Address: address, ZipCode: zipCode,
-		State: state, Country: country, UnstructuredProperties: unstructuredProperties}, nil
+	return &publicProfile, nil
 }
 
 // GetPublicIdentifiers gets a limited version of the account identifiers according to the visibility settings in Privacy
@@ -933,17 +833,20 @@ func ProfileFromMap(profileMap map[string]interface{}) Profile {
 
 // PublicProfile defines model for PublicProfile.
 type PublicProfile struct {
-	Address                *string                `json:"address"`
-	BirthYear              *int16                 `json:"birth_year"`
-	Country                *string                `json:"country"`
-	Email                  *string                `json:"email"`
-	FirstName              *string                `json:"first_name"`
-	LastName               *string                `json:"last_name"`
-	Phone                  *string                `json:"phone"`
-	PhotoURL               *string                `json:"photo_url"`
-	State                  *string                `json:"state"`
-	UnstructuredProperties map[string]interface{} `json:"unstructured_properties"`
-	ZipCode                *string                `json:"zip_code"`
+	Address                *string                `json:"address,omitempty"`
+	BirthYear              *int16                 `json:"birth_year,omitempty"`
+	Country                *string                `json:"country,omitempty"`
+	Email                  *string                `json:"email,omitempty"`
+	FirstName              *string                `json:"first_name,omitempty"`
+	LastName               *string                `json:"last_name,omitempty"`
+	Phone                  *string                `json:"phone,omitempty"`
+	PhotoURL               *string                `json:"photo_url,omitempty"`
+	PronunciationURL       *string                `json:"pronunciation_url,omitempty"`
+	Pronouns               *string                `json:"pronouns,omitempty"`
+	State                  *string                `json:"state,omitempty"`
+	UnstructuredProperties map[string]interface{} `json:"unstructured_properties,omitempty"`
+	Website                *string                `json:"website,omitempty"`
+	ZipCode                *string                `json:"zip_code,omitempty"`
 }
 
 // Device represents user devices entity.

--- a/core/model/user.go
+++ b/core/model/user.go
@@ -203,14 +203,14 @@ type Account struct {
 
 	Scopes []string
 
-	AuthTypes []AccountAuthType
+	AuthTypes []AccountAuthType `json:"identifiers"`
 
 	MFATypes []MFAType
 
-	Username      string
-	ExternalIDs   map[string]string
+	Username      string            `json:"username"`
+	ExternalIDs   map[string]string `json:"external_ids"`
 	SystemConfigs map[string]interface{}
-	Profile       Profile //one account has one profile
+	Profile       Profile `json:"profile"` //one account has one profile
 	Privacy       Privacy
 
 	Devices []Device
@@ -469,7 +469,7 @@ func (a *Account) GetPublicAccount(isConnection bool) (*PublicAccount, error) {
 	if err != nil {
 		return nil, errors.WrapErrorAction(logutils.ActionGet, "public identifiers", nil, err)
 	}
-	return &PublicAccount{Profile: *publicProfile, Identifiers: publicIdentifiers}, nil
+	return &PublicAccount{ID: a.ID, Verified: a.Verified, IsConnection: isConnection, Profile: *publicProfile, Identifiers: publicIdentifiers}, nil
 }
 
 // GetPublicProfile gets a limited version of the account profile according to the visibility settings in Privacy

--- a/driven/identitybb/adapter.go
+++ b/driven/identitybb/adapter.go
@@ -17,7 +17,7 @@ package identitybb
 import (
 	"core-building-block/core/model"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -63,7 +63,7 @@ func (a *Adapter) GetUserProfile(baseURL string, externalUser model.ExternalSyst
 	}
 
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, errors.WrapErrorAction(logutils.ActionRead, logutils.TypeResponse, nil, err)
 	}

--- a/driven/identitybb/adapter.go
+++ b/driven/identitybb/adapter.go
@@ -35,7 +35,7 @@ type Adapter struct {
 }
 
 // GetUserProfile gets user profile info for the provided user credentials
-func (a *Adapter) GetUserProfile(baseURL string, externalUser model.ExternalSystemUser, externalAccessToken string, l *logs.Log) (*model.Profile, error) {
+func (a *Adapter) GetUserProfile(baseURL string, externalUser model.ExternalSystemUser, externalAccessToken string, profileFields map[string]string, l *logs.Log) (*model.Profile, error) {
 	if baseURL == "" || externalAccessToken == "" {
 		return nil, errors.ErrorData(logutils.StatusMissing, "base url", nil)
 	}
@@ -80,7 +80,7 @@ func (a *Adapter) GetUserProfile(baseURL string, externalUser model.ExternalSyst
 		return nil, errors.WrapErrorAction(logutils.ActionUnmarshal, logutils.TypeResponseBody, nil, err)
 	}
 
-	profile := model.ProfileFromMap(profileData)
+	profile := model.ProfileFromMap(profileData, profileFields)
 
 	return &profile, nil
 }

--- a/driven/storage/adapter.go
+++ b/driven/storage/adapter.go
@@ -3504,6 +3504,8 @@ func (sa *Adapter) UpdateAccountProfile(context TransactionContext, profile mode
 	profileUpdate := bson.D{
 		primitive.E{Key: "$set", Value: bson.D{
 			primitive.E{Key: "profile.photo_url", Value: profile.PhotoURL},
+			primitive.E{Key: "profile.pronunciation_url", Value: profile.PronunciationURL},
+			primitive.E{Key: "profile.pronouns", Value: profile.Pronouns},
 			primitive.E{Key: "profile.first_name", Value: profile.FirstName},
 			primitive.E{Key: "profile.last_name", Value: profile.LastName},
 			primitive.E{Key: "profile.email", Value: profile.Email},
@@ -3513,6 +3515,7 @@ func (sa *Adapter) UpdateAccountProfile(context TransactionContext, profile mode
 			primitive.E{Key: "profile.zip_code", Value: profile.ZipCode},
 			primitive.E{Key: "profile.state", Value: profile.State},
 			primitive.E{Key: "profile.country", Value: profile.Country},
+			primitive.E{Key: "profile.website", Value: profile.Website},
 			primitive.E{Key: "profile.date_updated", Value: &now},
 			primitive.E{Key: "profile.unstructured_properties", Value: profile.UnstructuredProperties},
 		}},

--- a/driven/storage/adapter.go
+++ b/driven/storage/adapter.go
@@ -1575,26 +1575,6 @@ func (sa *Adapter) FindPublicAccounts(context TransactionContext, appID string, 
 
 	accounts := accountsFromStorage(results, &appOrg.ID, allAppsOrgs)
 	return accounts, nil
-
-	// var publicAccounts []model.PublicAccount
-	// for _, account := range result {
-
-	// 	not used?
-	// 	verified := false
-	// 	if account.Verified != nil && *account.Verified {
-	// 		verified = true
-	// 	}
-
-	// 	publicAccounts = append(publicAccounts, model.PublicAccount{
-	// 		ID:          account.ID,
-	// 		Username:    account.Username,
-	// 		FirstName:   account.Profile.FirstName,
-	// 		LastName:    account.Profile.LastName,
-	// 		Verified:    verified,
-	// 		IsFollowing: account.IsFollowing,
-	// 	})
-	// }
-	// return publicAccounts, nil
 }
 
 // FindAccountsByParams finds accounts by an arbitrary set of search params

--- a/driven/storage/conversions_user.go
+++ b/driven/storage/conversions_user.go
@@ -386,17 +386,17 @@ func accountGroupsToStorage(items []model.AccountGroup) []accountGroup {
 
 // Profile
 func profileFromStorage(item profile) model.Profile {
-	return model.Profile{ID: item.ID, PhotoURL: item.PhotoURL, FirstName: item.FirstName, LastName: item.LastName,
-		Email: item.Email, Phone: item.Phone, BirthYear: item.BirthYear, Address: item.Address, ZipCode: item.ZipCode,
-		State: item.State, Country: item.Country, DateCreated: item.DateCreated, DateUpdated: item.DateUpdated,
-		UnstructuredProperties: item.UnstructuredProperties}
+	return model.Profile{ID: item.ID, PhotoURL: item.PhotoURL, PronunciationURL: item.PronunciationURL, Pronouns: item.Pronouns,
+		FirstName: item.FirstName, LastName: item.LastName, Email: item.Email, Phone: item.Phone, BirthYear: item.BirthYear,
+		Address: item.Address, ZipCode: item.ZipCode, State: item.State, Country: item.Country, Website: item.Website,
+		DateCreated: item.DateCreated, DateUpdated: item.DateUpdated, UnstructuredProperties: item.UnstructuredProperties}
 }
 
 func profileToStorage(item model.Profile) profile {
-	return profile{ID: item.ID, PhotoURL: item.PhotoURL, FirstName: item.FirstName, LastName: item.LastName,
-		Email: item.Email, Phone: item.Phone, BirthYear: item.BirthYear, Address: item.Address, ZipCode: item.ZipCode,
-		State: item.State, Country: item.Country, DateCreated: item.DateCreated, DateUpdated: item.DateUpdated,
-		UnstructuredProperties: item.UnstructuredProperties}
+	return profile{ID: item.ID, PhotoURL: item.PhotoURL, PronunciationURL: item.PronunciationURL, Pronouns: item.Pronouns,
+		FirstName: item.FirstName, LastName: item.LastName, Email: item.Email, Phone: item.Phone, BirthYear: item.BirthYear,
+		Address: item.Address, ZipCode: item.ZipCode, State: item.State, Country: item.Country, Website: item.Website,
+		DateCreated: item.DateCreated, DateUpdated: item.DateUpdated, UnstructuredProperties: item.UnstructuredProperties}
 }
 
 // Device

--- a/driven/storage/model_user.go
+++ b/driven/storage/model_user.go
@@ -146,16 +146,19 @@ type accountAuthType struct {
 type profile struct {
 	ID string `bson:"id"`
 
-	PhotoURL  string `bson:"photo_url"`
-	FirstName string `bson:"first_name"`
-	LastName  string `bson:"last_name"`
-	Email     string `bson:"email"`
-	Phone     string `bson:"phone"`
-	BirthYear int16  `bson:"birth_year"`
-	Address   string `bson:"address"`
-	ZipCode   string `bson:"zip_code"`
-	State     string `bson:"state"`
-	Country   string `bson:"country"`
+	PhotoURL         string `bson:"photo_url"`
+	PronunciationURL string `bson:"pronunciation_url"`
+	Pronouns         string `bson:"pronouns"`
+	FirstName        string `bson:"first_name"`
+	LastName         string `bson:"last_name"`
+	Email            string `bson:"email"`
+	Phone            string `bson:"phone"`
+	BirthYear        int16  `bson:"birth_year"`
+	Address          string `bson:"address"`
+	ZipCode          string `bson:"zip_code"`
+	State            string `bson:"state"`
+	Country          string `bson:"country"`
+	Website          string `bson:"website"`
 
 	DateCreated time.Time  `bson:"date_created"`
 	DateUpdated *time.Time `bson:"date_updated"`

--- a/driver/web/adapter.go
+++ b/driver/web/adapter.go
@@ -133,6 +133,7 @@ func (we Adapter) Start() {
 	servicesSubRouter.HandleFunc("/account/preferences", we.wrapFunc(we.servicesApisHandler.getPreferences, we.auth.services.Standard)).Methods("GET")
 	servicesSubRouter.HandleFunc("/account/profile", we.wrapFunc(we.servicesApisHandler.getProfile, we.auth.services.User)).Methods("GET")
 	servicesSubRouter.HandleFunc("/account/profile", we.wrapFunc(we.servicesApisHandler.updateProfile, we.auth.services.User)).Methods("PUT")
+	servicesSubRouter.HandleFunc("/account/privacy", we.wrapFunc(we.servicesApisHandler.getPrivacy, we.auth.services.User)).Methods("GET")
 	servicesSubRouter.HandleFunc("/account/privacy", we.wrapFunc(we.servicesApisHandler.updatePrivacy, we.auth.services.User)).Methods("PUT")
 	servicesSubRouter.HandleFunc("/account/system-configs", we.wrapFunc(we.servicesApisHandler.getAccountSystemConfigs, we.auth.services.Standard)).Methods("GET")
 	servicesSubRouter.HandleFunc("/account/username", we.wrapFunc(we.servicesApisHandler.updateAccountUsername, we.auth.services.User)).Methods("PUT")

--- a/driver/web/apis_services.go
+++ b/driver/web/apis_services.go
@@ -953,7 +953,7 @@ func (h ServicesApisHandler) getPublicAccounts(l *logs.Log, r *http.Request, cla
 	accounts, err := h.coreAPIs.Services.SerGetPublicAccounts(claims.AppID, claims.OrgID, limit, offset, search,
 		firstName, lastName, username, followingID, followerID, claims.Subject)
 	if err != nil {
-		return l.HTTPResponseErrorAction("error finding accounts", model.TypeAccount, nil, err, http.StatusInternalServerError, true)
+		return l.HTTPResponseErrorAction(logutils.ActionGet, model.TypeAccount, nil, err, http.StatusInternalServerError, true)
 	}
 
 	if accounts == nil {

--- a/driver/web/apis_services.go
+++ b/driver/web/apis_services.go
@@ -689,6 +689,22 @@ func (h ServicesApisHandler) updateProfile(l *logs.Log, r *http.Request, claims 
 	return l.HTTPResponseSuccess()
 }
 
+func (h ServicesApisHandler) getPrivacy(l *logs.Log, r *http.Request, claims *tokenauth.Claims) logs.HTTPResponse {
+	privacy, err := h.coreAPIs.Services.SerGetAccountPrivacy(claims.OrgID, claims.AppID, claims.Subject)
+	if err != nil {
+		return l.HTTPResponseErrorAction(logutils.ActionGet, model.TypePrivacy, nil, err, http.StatusInternalServerError, true)
+	}
+
+	privacyResp := privacyToDef(privacy)
+
+	data, err := json.Marshal(privacyResp)
+	if err != nil {
+		return l.HTTPResponseErrorAction(logutils.ActionMarshal, model.TypePrivacy, nil, err, http.StatusInternalServerError, false)
+	}
+
+	return l.HTTPResponseSuccessJSON(data)
+}
+
 func (h ServicesApisHandler) updatePrivacy(l *logs.Log, r *http.Request, claims *tokenauth.Claims) logs.HTTPResponse {
 
 	var requestData Def.Privacy

--- a/driver/web/apis_services.go
+++ b/driver/web/apis_services.go
@@ -698,6 +698,10 @@ func (h ServicesApisHandler) updatePrivacy(l *logs.Log, r *http.Request, claims 
 	}
 
 	privacy := privacyFromDef(&requestData)
+	err = privacy.ValidateFieldVisibility(nil)
+	if err != nil {
+		return l.HTTPResponseErrorData(logutils.StatusInvalid, logutils.TypeRequestBody, logutils.StringArgs("field_visibility"), err, http.StatusBadRequest, true)
+	}
 
 	err = h.coreAPIs.Services.SerUpdateAccountPrivacy(claims.Subject, privacy)
 	if err != nil {

--- a/driver/web/conversions_application.go
+++ b/driver/web/conversions_application.go
@@ -418,6 +418,10 @@ func identityProviderSettingFromDef(item *Def.IdentityProviderSettings) *model.I
 	if item.IdentityBbBaseUrl != nil {
 		identityBBBaseURL = *item.IdentityBbBaseUrl
 	}
+	var identityBBProfileFields map[string]string
+	if item.IdentityBbProfileFields != nil {
+		identityBBProfileFields = *item.IdentityBbProfileFields
+	}
 
 	var adminAppAccessRoles []string
 	if item.AdminAppAccessRoles != nil {
@@ -427,8 +431,8 @@ func identityProviderSettingFromDef(item *Def.IdentityProviderSettings) *model.I
 	return &model.IdentityProviderSetting{IdentityProviderID: item.IdentityProviderId, UserIdentifierField: item.UserIdentifierField,
 		ExternalIDFields: externalIDFields, FirstNameField: firstNameField, MiddleNameField: middleNameField,
 		LastNameField: lastNameField, EmailField: emailField, FerpaField: ferpaField, RolesField: rolesField, GroupsField: groupsField,
-		UserSpecificFields: userSpecificFields, Roles: roles, Groups: groups,
-		AlwaysSyncProfile: alwaysSyncProfile, IdentityBBBaseURL: identityBBBaseURL, AdminAppAccessRoles: adminAppAccessRoles}
+		UserSpecificFields: userSpecificFields, Roles: roles, Groups: groups, AlwaysSyncProfile: alwaysSyncProfile,
+		IdentityBBBaseURL: identityBBBaseURL, IdentityBBProfileFields: identityBBProfileFields, AdminAppAccessRoles: adminAppAccessRoles}
 }
 
 func identityProviderSettingsToDef(items []model.IdentityProviderSetting) []Def.IdentityProviderSettings {

--- a/driver/web/conversions_user.go
+++ b/driver/web/conversions_user.go
@@ -347,7 +347,8 @@ func privacyToDef(item *model.Privacy) *Def.Privacy {
 	}
 
 	return &Def.Privacy{
-		Public: &item.Public,
+		Public:          &item.Public,
+		FieldVisibility: &item.FieldVisibility,
 	}
 }
 
@@ -360,8 +361,12 @@ func privacyFromDef(item *Def.Privacy) model.Privacy {
 	if item.Public != nil {
 		public = *item.Public
 	}
+	var fieldVisibility map[string]interface{}
+	if item.FieldVisibility != nil && len(*item.FieldVisibility) > 0 {
+		fieldVisibility = *item.FieldVisibility
+	}
 
-	return model.Privacy{Public: public}
+	return model.Privacy{Public: public, FieldVisibility: fieldVisibility}
 }
 
 func privacyFromDefNullable(item *Def.PrivacyNullable) model.Privacy {
@@ -373,8 +378,12 @@ func privacyFromDefNullable(item *Def.PrivacyNullable) model.Privacy {
 	if item.Public != nil {
 		public = *item.Public
 	}
+	var fieldVisibility map[string]interface{}
+	if item.FieldVisibility != nil && len(*item.FieldVisibility) > 0 {
+		fieldVisibility = *item.FieldVisibility
+	}
 
-	return model.Privacy{Public: public}
+	return model.Privacy{Public: public, FieldVisibility: fieldVisibility}
 }
 
 // MFA

--- a/driver/web/conversions_user.go
+++ b/driver/web/conversions_user.go
@@ -226,6 +226,14 @@ func profileFromDef(item *Def.Profile) model.Profile {
 	if item.PhotoUrl != nil {
 		photoURL = *item.PhotoUrl
 	}
+	var pronunciationURL string
+	if item.PronunciationUrl != nil {
+		pronunciationURL = *item.PronunciationUrl
+	}
+	var pronouns string
+	if item.Pronouns != nil {
+		pronouns = *item.Pronouns
+	}
 	var firstName string
 	if item.FirstName != nil {
 		firstName = *item.FirstName
@@ -262,15 +270,19 @@ func profileFromDef(item *Def.Profile) model.Profile {
 	if item.Country != nil {
 		country = *item.Country
 	}
+	var website string
+	if item.Website != nil {
+		website = *item.Website
+	}
 
 	var unstructuredProperties map[string]interface{}
 	if item.UnstructuredProperties != nil {
 		unstructuredProperties = *item.UnstructuredProperties
 	}
 
-	return model.Profile{PhotoURL: photoURL, FirstName: firstName, LastName: lastName,
-		Email: email, Phone: phone, BirthYear: int16(birthYear), Address: address, ZipCode: zipCode,
-		State: state, Country: country, UnstructuredProperties: unstructuredProperties}
+	return model.Profile{PhotoURL: photoURL, PronunciationURL: pronunciationURL, Pronouns: pronouns, FirstName: firstName,
+		LastName: lastName, Email: email, Phone: phone, BirthYear: int16(birthYear), Address: address, ZipCode: zipCode,
+		State: state, Country: country, Website: website, UnstructuredProperties: unstructuredProperties}
 }
 
 func profileToDef(item *model.Profile) *Def.Profile {
@@ -280,9 +292,10 @@ func profileToDef(item *model.Profile) *Def.Profile {
 
 	itemVal := *item
 	birthYear := int(itemVal.BirthYear)
-	return &Def.Profile{Id: &itemVal.ID, PhotoUrl: &itemVal.PhotoURL, FirstName: &itemVal.FirstName, LastName: &itemVal.LastName,
-		Email: &itemVal.Email, Phone: &itemVal.Phone, BirthYear: &birthYear, Address: &itemVal.Address, ZipCode: &itemVal.ZipCode,
-		State: &itemVal.State, Country: &itemVal.Country, UnstructuredProperties: &itemVal.UnstructuredProperties}
+	return &Def.Profile{Id: &itemVal.ID, PhotoUrl: &itemVal.PhotoURL, PronunciationUrl: &itemVal.PronunciationURL, Pronouns: &itemVal.Pronouns,
+		FirstName: &itemVal.FirstName, LastName: &itemVal.LastName, Email: &itemVal.Email, Phone: &itemVal.Phone, BirthYear: &birthYear,
+		Address: &itemVal.Address, ZipCode: &itemVal.ZipCode, State: &itemVal.State, Country: &itemVal.Country, Website: &itemVal.Website,
+		UnstructuredProperties: &itemVal.UnstructuredProperties}
 }
 
 func profileFromDefNullable(item *Def.ProfileNullable) model.Profile {
@@ -294,6 +307,14 @@ func profileFromDefNullable(item *Def.ProfileNullable) model.Profile {
 	if item.PhotoUrl != nil {
 		photoURL = *item.PhotoUrl
 	}
+	var pronunciationURL string
+	if item.PronunciationUrl != nil {
+		pronunciationURL = *item.PronunciationUrl
+	}
+	var pronouns string
+	if item.Pronouns != nil {
+		pronouns = *item.Pronouns
+	}
 	var firstName string
 	if item.FirstName != nil {
 		firstName = *item.FirstName
@@ -330,15 +351,19 @@ func profileFromDefNullable(item *Def.ProfileNullable) model.Profile {
 	if item.Country != nil {
 		country = *item.Country
 	}
+	var website string
+	if item.Website != nil {
+		website = *item.Website
+	}
 
 	var unstructuredProperties map[string]interface{}
 	if item.UnstructuredProperties != nil {
 		unstructuredProperties = *item.UnstructuredProperties
 	}
 
-	return model.Profile{PhotoURL: photoURL, FirstName: firstName, LastName: lastName,
-		Email: email, Phone: phone, BirthYear: int16(birthYear), Address: address, ZipCode: zipCode,
-		State: state, Country: country, UnstructuredProperties: unstructuredProperties}
+	return model.Profile{PhotoURL: photoURL, PronunciationURL: pronunciationURL, Pronouns: pronouns, FirstName: firstName,
+		LastName: lastName, Email: email, Phone: phone, BirthYear: int16(birthYear), Address: address, ZipCode: zipCode,
+		State: state, Country: country, Website: website, UnstructuredProperties: unstructuredProperties}
 }
 
 func privacyToDef(item *model.Privacy) *Def.Privacy {

--- a/driver/web/docs/gen/def.yaml
+++ b/driver/web/docs/gen/def.yaml
@@ -6377,6 +6377,11 @@ components:
           type: boolean
         identity_bb_base_url:
           type: string
+        identity_bb_profile_fields:
+          type: object
+          additionalProperties:
+            type: string
+          nullable: true
         admin_app_access_roles:
           type: array
           items:

--- a/driver/web/docs/gen/def.yaml
+++ b/driver/web/docs/gen/def.yaml
@@ -6973,6 +6973,10 @@ components:
           type: string
         photo_url:
           type: string
+        pronunciation_url:
+          type: string
+        pronouns:
+          type: string
         first_name:
           type: string
         last_name:
@@ -6998,6 +7002,8 @@ components:
         country:
           type: string
           nullable: true
+        website:
+          type: string
         unstructured_properties:
           type: object
           nullable: true
@@ -7008,6 +7014,12 @@ components:
         photo_url:
           type: string
           nullable: true
+        pronunciation_url:
+          type: string
+          nullable: true
+        pronouns:
+          type: string
+          nullable: true
         first_name:
           type: string
           nullable: true
@@ -7033,6 +7045,9 @@ components:
           type: string
           nullable: true
         country:
+          type: string
+          nullable: true
+        website:
           type: string
           nullable: true
         unstructured_properties:

--- a/driver/web/docs/gen/def.yaml
+++ b/driver/web/docs/gen/def.yaml
@@ -1457,6 +1457,29 @@ paths:
         '500':
           description: Internal error
   /services/account/privacy:
+    get:
+      tags:
+        - Services
+      summary: Get user privacy settings
+      description: |
+        Returns a user's privacy settings
+
+        **Auth:** Requires user auth token
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Privacy'
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '500':
+          description: Internal error
     put:
       tags:
         - Services

--- a/driver/web/docs/gen/def.yaml
+++ b/driver/web/docs/gen/def.yaml
@@ -7044,13 +7044,16 @@ components:
         field_visibility:
           type: object
           additionalProperties: true
-          nullable: true
     PrivacyNullable:
       type: object
       nullable: true
       properties:
         public:
           type: boolean
+          nullable: true
+        field_visibility:
+          type: object
+          additionalProperties: true
           nullable: true
     Username:
       required:

--- a/driver/web/docs/gen/def.yaml
+++ b/driver/web/docs/gen/def.yaml
@@ -1473,6 +1473,18 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Privacy'
+            example:
+              public: true
+              field_visibility:
+                profile:
+                  first_name: public
+                  last_name: connections
+                  email: private
+                auth_types:
+                  id1: public
+                  id3: connections
+                  id2: private
+                username: public
         required: true
       responses:
         '200':
@@ -6819,21 +6831,35 @@ components:
           type: string
     PublicAccount:
       required:
-        - id
+        - is_connection
+        - profile
+        - identifiers
       type: object
       properties:
         id:
-          type: string
-        username:
-          type: string
-        first_name:
-          type: string
-        last_name:
           type: string
         verified:
           type: boolean
         is_following:
           type: boolean
+        is_connection:
+          type: boolean
+        profile:
+          $ref: '#/components/schemas/ProfileNullable'
+        identifiers:
+          type: array
+          items:
+            $ref: '#/components/schemas/PublicAccountIdentifier'
+    PublicAccountIdentifier:
+      required:
+        - code
+        - identifier
+      type: object
+      properties:
+        code:
+          type: string
+        identifier:
+          type: string
     PartialAccount:
       required:
         - id
@@ -7015,6 +7041,10 @@ components:
       properties:
         public:
           type: boolean
+        field_visibility:
+          type: object
+          additionalProperties: true
+          nullable: true
     PrivacyNullable:
       type: object
       nullable: true

--- a/driver/web/docs/gen/def.yaml
+++ b/driver/web/docs/gen/def.yaml
@@ -6856,6 +6856,7 @@ components:
           type: string
     PublicAccount:
       required:
+        - id
         - is_connection
         - profile
         - identifiers

--- a/driver/web/docs/gen/def.yaml
+++ b/driver/web/docs/gen/def.yaml
@@ -7046,6 +7046,7 @@ components:
         field_visibility:
           type: object
           additionalProperties: true
+          nullable: true
     PrivacyNullable:
       type: object
       nullable: true

--- a/driver/web/docs/gen/def.yaml
+++ b/driver/web/docs/gen/def.yaml
@@ -1482,8 +1482,10 @@ paths:
                   email: private
                 auth_types:
                   id1: public
-                  id3: connections
                   id2: private
+                external_ids:
+                  net_id: connections
+                  uin: public
                 username: public
         required: true
       responses:

--- a/driver/web/docs/gen/gen_types.go
+++ b/driver/web/docs/gen/gen_types.go
@@ -570,7 +570,7 @@ type Permission struct {
 
 // Privacy defines model for Privacy.
 type Privacy struct {
-	FieldVisibility *map[string]interface{} `json:"field_visibility,omitempty"`
+	FieldVisibility *map[string]interface{} `json:"field_visibility"`
 	Public          *bool                   `json:"public,omitempty"`
 }
 

--- a/driver/web/docs/gen/gen_types.go
+++ b/driver/web/docs/gen/gen_types.go
@@ -371,22 +371,23 @@ type Follow struct {
 
 // IdentityProviderSettings defines model for IdentityProviderSettings.
 type IdentityProviderSettings struct {
-	AdminAppAccessRoles *[]string          `json:"admin_app_access_roles,omitempty"`
-	AlwaysSyncProfile   *bool              `json:"always_sync_profile,omitempty"`
-	EmailField          *string            `json:"email_field,omitempty"`
-	ExternalIdFields    *map[string]string `json:"external_id_fields"`
-	FerpaField          *string            `json:"ferpa_field,omitempty"`
-	FirstNameField      *string            `json:"first_name_field,omitempty"`
-	Groups              *map[string]string `json:"groups"`
-	GroupsField         *string            `json:"groups_field,omitempty"`
-	IdentityBbBaseUrl   *string            `json:"identity_bb_base_url,omitempty"`
-	IdentityProviderId  string             `json:"identity_provider_id"`
-	LastNameField       *string            `json:"last_name_field,omitempty"`
-	MiddleNameField     *string            `json:"middle_name_field,omitempty"`
-	Roles               *map[string]string `json:"roles"`
-	RolesField          *string            `json:"roles_field,omitempty"`
-	UserIdentifierField string             `json:"user_identifier_field"`
-	UserSpecificFields  *[]string          `json:"user_specific_fields"`
+	AdminAppAccessRoles     *[]string          `json:"admin_app_access_roles,omitempty"`
+	AlwaysSyncProfile       *bool              `json:"always_sync_profile,omitempty"`
+	EmailField              *string            `json:"email_field,omitempty"`
+	ExternalIdFields        *map[string]string `json:"external_id_fields"`
+	FerpaField              *string            `json:"ferpa_field,omitempty"`
+	FirstNameField          *string            `json:"first_name_field,omitempty"`
+	Groups                  *map[string]string `json:"groups"`
+	GroupsField             *string            `json:"groups_field,omitempty"`
+	IdentityBbBaseUrl       *string            `json:"identity_bb_base_url,omitempty"`
+	IdentityBbProfileFields *map[string]string `json:"identity_bb_profile_fields"`
+	IdentityProviderId      string             `json:"identity_provider_id"`
+	LastNameField           *string            `json:"last_name_field,omitempty"`
+	MiddleNameField         *string            `json:"middle_name_field,omitempty"`
+	Roles                   *map[string]string `json:"roles"`
+	RolesField              *string            `json:"roles_field,omitempty"`
+	UserIdentifierField     string             `json:"user_identifier_field"`
+	UserSpecificFields      *[]string          `json:"user_specific_fields"`
 }
 
 // InactiveExpirePolicy defines model for InactiveExpirePolicy.

--- a/driver/web/docs/gen/gen_types.go
+++ b/driver/web/docs/gen/gen_types.go
@@ -591,8 +591,11 @@ type Profile struct {
 	LastName               *string                 `json:"last_name,omitempty"`
 	Phone                  *string                 `json:"phone"`
 	PhotoUrl               *string                 `json:"photo_url,omitempty"`
+	Pronouns               *string                 `json:"pronouns,omitempty"`
+	PronunciationUrl       *string                 `json:"pronunciation_url,omitempty"`
 	State                  *string                 `json:"state"`
 	UnstructuredProperties *map[string]interface{} `json:"unstructured_properties"`
+	Website                *string                 `json:"website,omitempty"`
 	ZipCode                *string                 `json:"zip_code"`
 }
 
@@ -606,8 +609,11 @@ type ProfileNullable struct {
 	LastName               *string                 `json:"last_name"`
 	Phone                  *string                 `json:"phone"`
 	PhotoUrl               *string                 `json:"photo_url"`
+	Pronouns               *string                 `json:"pronouns"`
+	PronunciationUrl       *string                 `json:"pronunciation_url"`
 	State                  *string                 `json:"state"`
 	UnstructuredProperties *map[string]interface{} `json:"unstructured_properties"`
+	Website                *string                 `json:"website"`
 	ZipCode                *string                 `json:"zip_code"`
 }
 

--- a/driver/web/docs/gen/gen_types.go
+++ b/driver/web/docs/gen/gen_types.go
@@ -570,7 +570,8 @@ type Permission struct {
 
 // Privacy defines model for Privacy.
 type Privacy struct {
-	Public *bool `json:"public,omitempty"`
+	FieldVisibility *map[string]interface{} `json:"field_visibility"`
+	Public          *bool                   `json:"public,omitempty"`
 }
 
 // PrivacyNullable defines model for PrivacyNullable.
@@ -617,12 +618,18 @@ type PubKey struct {
 
 // PublicAccount defines model for PublicAccount.
 type PublicAccount struct {
-	FirstName   *string `json:"first_name,omitempty"`
-	Id          string  `json:"id"`
-	IsFollowing *bool   `json:"is_following,omitempty"`
-	LastName    *string `json:"last_name,omitempty"`
-	Username    *string `json:"username,omitempty"`
-	Verified    *bool   `json:"verified,omitempty"`
+	Id           *string                   `json:"id,omitempty"`
+	Identifiers  []PublicAccountIdentifier `json:"identifiers"`
+	IsConnection bool                      `json:"is_connection"`
+	IsFollowing  *bool                     `json:"is_following,omitempty"`
+	Profile      *ProfileNullable          `json:"profile"`
+	Verified     *bool                     `json:"verified,omitempty"`
+}
+
+// PublicAccountIdentifier defines model for PublicAccountIdentifier.
+type PublicAccountIdentifier struct {
+	Code       string `json:"code"`
+	Identifier string `json:"identifier"`
 }
 
 // ServiceAccount defines model for ServiceAccount.

--- a/driver/web/docs/gen/gen_types.go
+++ b/driver/web/docs/gen/gen_types.go
@@ -625,7 +625,7 @@ type PubKey struct {
 
 // PublicAccount defines model for PublicAccount.
 type PublicAccount struct {
-	Id           *string                   `json:"id,omitempty"`
+	Id           string                    `json:"id"`
 	Identifiers  []PublicAccountIdentifier `json:"identifiers"`
 	IsConnection bool                      `json:"is_connection"`
 	IsFollowing  *bool                     `json:"is_following,omitempty"`

--- a/driver/web/docs/gen/gen_types.go
+++ b/driver/web/docs/gen/gen_types.go
@@ -570,13 +570,14 @@ type Permission struct {
 
 // Privacy defines model for Privacy.
 type Privacy struct {
-	FieldVisibility *map[string]interface{} `json:"field_visibility"`
+	FieldVisibility *map[string]interface{} `json:"field_visibility,omitempty"`
 	Public          *bool                   `json:"public,omitempty"`
 }
 
 // PrivacyNullable defines model for PrivacyNullable.
 type PrivacyNullable struct {
-	Public *bool `json:"public"`
+	FieldVisibility *map[string]interface{} `json:"field_visibility"`
+	Public          *bool                   `json:"public"`
 }
 
 // Profile defines model for Profile.

--- a/driver/web/docs/resources/services/account/privacy.yaml
+++ b/driver/web/docs/resources/services/account/privacy.yaml
@@ -1,3 +1,26 @@
+get:
+  tags:
+  - Services
+  summary: Get user privacy settings
+  description: |
+    Returns a user's privacy settings
+
+    **Auth:** Requires user auth token
+  security:
+    - bearerAuth: []
+  responses:
+    200:
+      description: Success
+      content:
+        application/json:
+          schema:
+            $ref: "../../../schemas/user/Privacy.yaml"
+    400:
+      description: Bad request
+    401:
+      description: Unauthorized
+    500:
+      description: Internal error
 put:
   tags:
   - Services

--- a/driver/web/docs/resources/services/account/privacy.yaml
+++ b/driver/web/docs/resources/services/account/privacy.yaml
@@ -23,8 +23,10 @@ put:
               email: private
             auth_types:
               id1: public
-              id3: connections
               id2: private
+            external_ids:
+              net_id: connections
+              uin: public
             username: public
     required: true
   responses:

--- a/driver/web/docs/resources/services/account/privacy.yaml
+++ b/driver/web/docs/resources/services/account/privacy.yaml
@@ -14,6 +14,18 @@ put:
       application/json:
         schema:
           $ref: "../../../schemas/user/Privacy.yaml"
+        example:
+          public: true
+          field_visibility:
+            profile:
+              first_name: public
+              last_name: connections
+              email: private
+            auth_types:
+              id1: public
+              id3: connections
+              id2: private
+            username: public
     required: true
   responses:
     200:

--- a/driver/web/docs/schemas/application/IdentityProviderSettings.yaml
+++ b/driver/web/docs/schemas/application/IdentityProviderSettings.yaml
@@ -42,9 +42,14 @@ properties:
       type: string
     nullable: true
   always_sync_profile:
-    type: boolean 
+    type: boolean
   identity_bb_base_url:
     type: string
+  identity_bb_profile_fields:
+    type: object
+    additionalProperties:
+      type: string
+    nullable: true
   admin_app_access_roles:
     type: array
     items:

--- a/driver/web/docs/schemas/index.yaml
+++ b/driver/web/docs/schemas/index.yaml
@@ -82,6 +82,8 @@ Account:
   $ref: "./user/Account.yaml"
 PublicAccount:
   $ref: "./user/PublicAccount.yaml"
+PublicAccountIdentifier:
+  $ref: "./user/PublicAccountIdentifier.yaml"
 PartialAccount:
   $ref: "./user/PartialAccount.yaml"
 DeletedAppOrgMembership:

--- a/driver/web/docs/schemas/user/Privacy.yaml
+++ b/driver/web/docs/schemas/user/Privacy.yaml
@@ -2,3 +2,7 @@ type: object
 properties:
   public:
     type: boolean
+  field_visibility:
+    type: object
+    additionalProperties: true
+    nullable: true

--- a/driver/web/docs/schemas/user/Privacy.yaml
+++ b/driver/web/docs/schemas/user/Privacy.yaml
@@ -5,3 +5,4 @@ properties:
   field_visibility:
     type: object
     additionalProperties: true
+    nullable: true

--- a/driver/web/docs/schemas/user/Privacy.yaml
+++ b/driver/web/docs/schemas/user/Privacy.yaml
@@ -5,4 +5,3 @@ properties:
   field_visibility:
     type: object
     additionalProperties: true
-    nullable: true

--- a/driver/web/docs/schemas/user/PrivacyNullable.yaml
+++ b/driver/web/docs/schemas/user/PrivacyNullable.yaml
@@ -4,3 +4,7 @@ properties:
   public:
     type: boolean
     nullable: true
+  field_visibility:
+    type: object
+    additionalProperties: true
+    nullable: true

--- a/driver/web/docs/schemas/user/Profile.yaml
+++ b/driver/web/docs/schemas/user/Profile.yaml
@@ -7,6 +7,10 @@ properties:
     type: string
   photo_url:
     type: string
+  pronunciation_url:
+    type: string
+  pronouns:
+    type: string
   first_name:
     type: string
   last_name:
@@ -32,6 +36,8 @@ properties:
   country:
     type: string
     nullable: true
+  website:
+    type: string
   unstructured_properties:
     type: object
     nullable: true 

--- a/driver/web/docs/schemas/user/ProfileNullable.yaml
+++ b/driver/web/docs/schemas/user/ProfileNullable.yaml
@@ -4,6 +4,12 @@ properties:
   photo_url:
     type: string
     nullable: true
+  pronunciation_url:
+    type: string
+    nullable: true
+  pronouns:
+    type: string
+    nullable: true
   first_name:
     type: string
     nullable: true
@@ -29,6 +35,9 @@ properties:
     type: string
     nullable: true
   country:
+    type: string
+    nullable: true
+  website:
     type: string
     nullable: true
   unstructured_properties:

--- a/driver/web/docs/schemas/user/PublicAccount.yaml
+++ b/driver/web/docs/schemas/user/PublicAccount.yaml
@@ -1,4 +1,5 @@
 required:
+  - id
   - is_connection
   - profile
   - identifiers

--- a/driver/web/docs/schemas/user/PublicAccount.yaml
+++ b/driver/web/docs/schemas/user/PublicAccount.yaml
@@ -1,16 +1,20 @@
 required:
-  - id
+  - is_connection
+  - profile
+  - identifiers
 type: object
 properties:
   id:
-    type: string
-  username:
-    type: string
-  first_name:
-    type: string
-  last_name:
     type: string
   verified:
     type: boolean
   is_following:
     type: boolean
+  is_connection:
+    type: boolean
+  profile:
+    $ref: "./ProfileNullable.yaml"
+  identifiers:
+    type: array
+    items:
+      $ref: "./PublicAccountIdentifier.yaml"

--- a/driver/web/docs/schemas/user/PublicAccountIdentifier.yaml
+++ b/driver/web/docs/schemas/user/PublicAccountIdentifier.yaml
@@ -1,0 +1,9 @@
+required:
+  - code
+  - identifier
+type: object
+properties:
+  code:
+    type: string
+  identifier:
+    type: string

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -227,6 +227,28 @@ func GetPrintableString(v *string, defaultVal string) string {
 	return defaultVal
 }
 
+// GetMapEntryFromPath returns the data entry corresponding to path, a period-separated string
+func GetMapEntryFromPath(data map[string]interface{}, path string) interface{} {
+	if len(data) == 0 {
+		return nil
+	}
+
+	splitPath := strings.Split(path, ".")
+	entry, ok := data[splitPath[0]]
+	if !ok {
+		return nil
+	}
+	if len(splitPath) == 1 {
+		return entry
+	}
+
+	entryData, ok := entry.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	return GetMapEntryFromPath(entryData, strings.Join(splitPath[1:], "."))
+}
+
 // StartTimer starts a timer with the given name, period, and function to call when the timer goes off
 func StartTimer(timer *time.Timer, timerDone chan bool, period time.Duration, periodicFunc func(), name string, logger *logs.Logger) {
 	if logger != nil {


### PR DESCRIPTION
## Description
This PR adds a `FieldVisibility` field to `Account.Privacy`, which allows users to choose between 3 visibility options (`public`, `connections`, and `private`) for each field in their profile, each of their account identifiers (email, phone, etc.) and external IDs (net ID, uin), and their username.

New fields (`PronunciationURL`, `Pronouns`, and `Website`) have been added to the `Profile` model and additional university-specific fields (whether obtained from the Identity BB or user-customized) will be stored in `UnstructuredProperties`.

`IdentityBBProfileFields` has been added to `ApplicationOrganization` to allow admins to specify how the data from the Identity BB will be stored in `UnstructuredProperties`.

**Resolves #727**

[comment]: # (This project only accepts pull requests related to open issues.)
[comment]: # (If suggesting a new feature or change, please discuss it in an issue first.)
[comment]: # (If fixing a bug, there should be an issue describing it with steps to reproduce.)

## Review Time Estimate
_Please give your idea of how soon this pull request needs to be reviewed by selecting one of the options below. This can be based on the criticality of the issue at hand and/or other relevant factors._

[comment]: # (To select an option, please put an 'x' in the applicable box.)
[comment]: # (If you're unsure about any of these, don't hesitate to ask. We're here to help!.)

- [ ] Immediately
- [x] Within a week
- [ ] When possible

## Type of changes
_Please select a relevant option:_

[comment]: # (To select an option, please put an 'x' in the applicable box.)
[comment]: # (If you're unsure about any of these, don't hesitate to ask. We're here to help!.)

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Other (any another change that does not fall in one of the above categories.)

## Checklist:
_Please select all applicable options:_

[comment]: # (To select your options, please put an 'x' in the all boxes that apply.)
[comment]: # (If you're unsure about any of these, don't hesitate to ask. We're here to help!.)

- [x] I have signed the Rokwire Contributor License Agreement ([CLA](https://rokwire.org/rokwire_cla)). (_Any contributor who is not an employee of the University of Illinois whose official duties include contributing to the Rokwire software, or who is not paid by the Rokwire project, needs to sign the CLA before their contribution can be accepted._)
- [x] I have updated the [CHANGELOG](../CHANGELOG.md).
- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My change requires updating the documentation.
- [x] I have made necessary changes to the documentation.
- [ ] I have added tests related to my changes.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.

---

[comment]: # (Template credit: This pull request template is based on Embedded Artistry {https://github.com/embeddedartistry/templates/blob/master/.github/PULL_REQUEST_TEMPLATE.md}, Clowder {https://github.com/clowder-framework/clowder/blob/develop/.github/PULL_REQUEST_TEMPLATE.md}, and TalAter {https://github.com/TalAter/open-source-templates} templates.)
