### PR TITLE
[ID-789]Admin API for filtering signed-in accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Admin API for filtering signed-in accounts [#789](https://github.com/rokwire/core-building-block/issues/789)
+
 ## [1.56.0] - 2025-08-15
 ### Changed
 - Twilio phone login does not perform verification - more logs added [#790](https://github.com/rokwire/core-building-block/issues/790)

--- a/core/apis.go
+++ b/core/apis.go
@@ -536,8 +536,8 @@ func (s *administrationImpl) AdmGetApplicationLoginSessions(appID string, orgID 
 	return s.app.admGetApplicationLoginSessions(appID, orgID, identifier, accountAuthTypeIdentifier, appTypeID, appTypeIdentifier, anonymous, deviceID, ipAddress)
 }
 
-func (s *administrationImpl) AdmGetSessions(userRole *string, startTime *string, endTime *string) ([]model.Sessions, error) {
-	return s.app.admGetSessions(userRole, startTime, endTime)
+func (s *administrationImpl) AdmGetSessions(userRole *string, startTime *string, endTime *string, anonymous *bool) ([]model.Sessions, error) {
+	return s.app.admGetSessions(userRole, startTime, endTime, anonymous)
 }
 
 func (s *administrationImpl) AdmDeleteApplicationLoginSession(appID string, orgID string, currentAccountID string, identifier string, sessionID string, l *logs.Log) error {

--- a/core/apis.go
+++ b/core/apis.go
@@ -536,7 +536,7 @@ func (s *administrationImpl) AdmGetApplicationLoginSessions(appID string, orgID 
 	return s.app.admGetApplicationLoginSessions(appID, orgID, identifier, accountAuthTypeIdentifier, appTypeID, appTypeIdentifier, anonymous, deviceID, ipAddress)
 }
 
-func (s *administrationImpl) AdmGetSessions(userRole *string, startTime *string, endTime *string, anonymous *bool) ([]model.Sessions, error) {
+func (s *administrationImpl) AdmGetSessions(userRole *string, startTime *time.Time, endTime *time.Time, anonymous *bool) ([]model.Sessions, error) {
 	return s.app.admGetSessions(userRole, startTime, endTime, anonymous)
 }
 

--- a/core/apis.go
+++ b/core/apis.go
@@ -536,6 +536,10 @@ func (s *administrationImpl) AdmGetApplicationLoginSessions(appID string, orgID 
 	return s.app.admGetApplicationLoginSessions(appID, orgID, identifier, accountAuthTypeIdentifier, appTypeID, appTypeIdentifier, anonymous, deviceID, ipAddress)
 }
 
+func (s *administrationImpl) AdmGetSessions(userRole *string, startTime *string, endTime *string) ([]model.Sessions, error) {
+	return s.app.admGetSessions(userRole, startTime, endTime)
+}
+
 func (s *administrationImpl) AdmDeleteApplicationLoginSession(appID string, orgID string, currentAccountID string, identifier string, sessionID string, l *logs.Log) error {
 	return s.app.admDeleteApplicationLoginSession(appID, orgID, currentAccountID, identifier, sessionID, l)
 }

--- a/core/app_administration.go
+++ b/core/app_administration.go
@@ -1170,7 +1170,7 @@ func (app *application) admGetApplicationLoginSessions(appID string, orgID strin
 	return loginSessions, nil
 }
 
-func (app *application) admGetSessions(userRole *string, startTime *string, endTime *string, anonymous *bool) ([]model.Sessions, error) {
+func (app *application) admGetSessions(userRole *string, startTime *time.Time, endTime *time.Time, anonymous *bool) ([]model.Sessions, error) {
 	sessions, err := app.storage.FindJoinedSessions(userRole, startTime, endTime, anonymous)
 	if err != nil {
 		return nil, nil

--- a/core/app_administration.go
+++ b/core/app_administration.go
@@ -1171,8 +1171,12 @@ func (app *application) admGetApplicationLoginSessions(appID string, orgID strin
 }
 
 func (app *application) admGetSessions(userRole *string, startTime *string, endTime *string, anonymous *bool) ([]model.Sessions, error) {
+	sessions, err := app.storage.FindJoinedSessions(userRole, startTime, endTime, anonymous)
+	if err != nil {
+		return nil, nil
+	}
 
-	return nil, nil
+	return sessions, nil
 }
 
 func (app *application) admDeleteApplicationLoginSession(appID string, orgID string, currentAccountID string, identifier string, sessionID string, l *logs.Log) error {

--- a/core/app_administration.go
+++ b/core/app_administration.go
@@ -1170,6 +1170,10 @@ func (app *application) admGetApplicationLoginSessions(appID string, orgID strin
 	return loginSessions, nil
 }
 
+func (app *application) admGetSessions(userRole *string, startTime *string, endTime *string) ([]model.Sessions, error) {
+	return nil, nil
+}
+
 func (app *application) admDeleteApplicationLoginSession(appID string, orgID string, currentAccountID string, identifier string, sessionID string, l *logs.Log) error {
 	//1. do not allow to logout the current account
 	if currentAccountID == identifier {

--- a/core/app_administration.go
+++ b/core/app_administration.go
@@ -1170,7 +1170,8 @@ func (app *application) admGetApplicationLoginSessions(appID string, orgID strin
 	return loginSessions, nil
 }
 
-func (app *application) admGetSessions(userRole *string, startTime *string, endTime *string) ([]model.Sessions, error) {
+func (app *application) admGetSessions(userRole *string, startTime *string, endTime *string, anonymous *bool) ([]model.Sessions, error) {
+
 	return nil, nil
 }
 

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -100,7 +100,7 @@ type Administration interface {
 
 	AdmGetApplicationLoginSessions(appID string, orgID string, identifier *string, accountAuthTypeIdentifier *string,
 		appTypeID *string, appTypeIdentifier *string, anonymous *bool, deviceID *string, ipAddress *string) ([]model.LoginSession, error)
-	AdmGetSessions(userRole *string, starTime *string, endTime *string, anonymous *bool) ([]model.Sessions, error)
+	AdmGetSessions(userRole *string, starTime *time.Time, endTime *time.Time, anonymous *bool) ([]model.Sessions, error)
 	AdmDeleteApplicationLoginSession(appID string, orgID string, currentAccountID string, identifier string, sessionID string, l *logs.Log) error
 
 	AdmGetApplicationAccountDevices(appID string, orgID string, accountID string, l *logs.Log) ([]model.Device, error)
@@ -183,7 +183,7 @@ type Storage interface {
 	FindAccountsByUsername(context storage.TransactionContext, appOrg *model.ApplicationOrganization, username string) ([]model.Account, error)
 	FindDeletedOrgAppMemberships(appID string, orgID string, startTime *time.Time) ([]model.DeletedOrgAppMembership, error)
 	SaveAccount(context storage.TransactionContext, account *model.Account) error
-	FindJoinedSessions(userRole *string, startTime *string, endTime *string, anonymous *bool) ([]model.Sessions, error)
+	FindJoinedSessions(userRole *string, startTime *time.Time, endTime *time.Time, anonymous *bool) ([]model.Sessions, error)
 	UpdateAccountPreferences(context storage.TransactionContext, cOrgID string, cAppID string, accountID string, preferences map[string]interface{}) error
 	UpdateAccountSystemConfigs(context storage.TransactionContext, accountID string, configs map[string]interface{}) error
 	InsertAccountPermissions(context storage.TransactionContext, accountID string, appOrgID string, permissions []model.Permission) error

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -100,6 +100,7 @@ type Administration interface {
 
 	AdmGetApplicationLoginSessions(appID string, orgID string, identifier *string, accountAuthTypeIdentifier *string,
 		appTypeID *string, appTypeIdentifier *string, anonymous *bool, deviceID *string, ipAddress *string) ([]model.LoginSession, error)
+	AdmGetSessions(userRole *string, starTime *string, endTime *string) ([]model.Sessions, error)
 	AdmDeleteApplicationLoginSession(appID string, orgID string, currentAccountID string, identifier string, sessionID string, l *logs.Log) error
 
 	AdmGetApplicationAccountDevices(appID string, orgID string, accountID string, l *logs.Log) ([]model.Device, error)

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -183,7 +183,7 @@ type Storage interface {
 	FindAccountsByUsername(context storage.TransactionContext, appOrg *model.ApplicationOrganization, username string) ([]model.Account, error)
 	FindDeletedOrgAppMemberships(appID string, orgID string, startTime *time.Time) ([]model.DeletedOrgAppMembership, error)
 	SaveAccount(context storage.TransactionContext, account *model.Account) error
-
+	FindJoinedSessions(userRole *string, startTime *string, endTime *string, anonymous *bool) ([]model.Sessions, error)
 	UpdateAccountPreferences(context storage.TransactionContext, cOrgID string, cAppID string, accountID string, preferences map[string]interface{}) error
 	UpdateAccountSystemConfigs(context storage.TransactionContext, accountID string, configs map[string]interface{}) error
 	InsertAccountPermissions(context storage.TransactionContext, accountID string, appOrgID string, permissions []model.Permission) error

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -100,7 +100,7 @@ type Administration interface {
 
 	AdmGetApplicationLoginSessions(appID string, orgID string, identifier *string, accountAuthTypeIdentifier *string,
 		appTypeID *string, appTypeIdentifier *string, anonymous *bool, deviceID *string, ipAddress *string) ([]model.LoginSession, error)
-	AdmGetSessions(userRole *string, starTime *string, endTime *string) ([]model.Sessions, error)
+	AdmGetSessions(userRole *string, starTime *string, endTime *string, anonymous *bool) ([]model.Sessions, error)
 	AdmDeleteApplicationLoginSession(appID string, orgID string, currentAccountID string, identifier string, sessionID string, l *logs.Log) error
 
 	AdmGetApplicationAccountDevices(appID string, orgID string, accountID string, l *logs.Log) ([]model.Device, error)

--- a/core/model/auth.go
+++ b/core/model/auth.go
@@ -117,7 +117,7 @@ type Sessions struct {
 	FirstName     *string
 	LastName      *string
 	Email         *string
-	LastLoginDate string
+	LastLoginDate time.Time
 	ExternalIDs   *map[string]string
 	Anonymous     *bool
 }

--- a/core/model/auth.go
+++ b/core/model/auth.go
@@ -111,6 +111,16 @@ type LoginSession struct {
 	DateCreated time.Time
 }
 
+// Sessions represents login session
+type Sessions struct {
+	UserRole      *string
+	FirstName     *string
+	LastName      *string
+	Email         *string
+	LastLoginDate string
+	ExternalIDs   *map[string]string
+}
+
 // IsExpired says if the sessions is expired
 func (ls LoginSession) IsExpired() bool {
 	loginsSessionsSetting := ls.AppOrg.LoginsSessionsSetting

--- a/core/model/auth.go
+++ b/core/model/auth.go
@@ -119,6 +119,7 @@ type Sessions struct {
 	Email         *string
 	LastLoginDate string
 	ExternalIDs   *map[string]string
+	Anonymous     *bool
 }
 
 // IsExpired says if the sessions is expired

--- a/driver/web/adapter.go
+++ b/driver/web/adapter.go
@@ -182,6 +182,7 @@ func (we Adapter) Start() {
 	adminSubrouter.HandleFunc("/organization/applications", we.wrapFunc(we.adminApisHandler.getApplications, we.auth.admin.User)).Methods("GET")
 
 	adminSubrouter.HandleFunc("/application/login-sessions", we.wrapFunc(we.adminApisHandler.getApplicationLoginSessions, we.auth.admin.Permissions)).Methods("GET")
+	adminSubrouter.HandleFunc("/application/sessions", we.wrapFunc(we.adminApisHandler.getSessions, we.auth.admin.Permissions)).Methods("GET")
 
 	adminSubrouter.HandleFunc("/application/configs", we.wrapFunc(we.adminApisHandler.getApplicationConfigs, we.auth.admin.Permissions)).Methods("GET")
 	adminSubrouter.HandleFunc("/application/configs", we.wrapFunc(we.adminApisHandler.createApplicationConfig, we.auth.admin.Permissions)).Methods("POST")

--- a/driver/web/apis_admin.go
+++ b/driver/web/apis_admin.go
@@ -777,7 +777,14 @@ func (h AdminApisHandler) getSessions(l *logs.Log, r *http.Request, claims *toke
 		endTime = &endTimeFromQuery
 	}
 
-	getSessions, err := h.coreAPIs.Administration.AdmGetSessions(userRole, startTime, endTime)
+	anonymousFromQuery := r.URL.Query().Get("anonymous")
+	var anonymous *bool
+	if len(anonymousFromQuery) > 0 {
+		result, _ := strconv.ParseBool(anonymousFromQuery)
+		anonymous = &result
+	}
+
+	getSessions, err := h.coreAPIs.Administration.AdmGetSessions(userRole, startTime, endTime, anonymous)
 	if err != nil {
 		return l.HTTPResponseErrorAction("error finding login sessions", model.TypeLoginSession, nil, err, http.StatusInternalServerError, true)
 	}

--- a/driver/web/apis_admin.go
+++ b/driver/web/apis_admin.go
@@ -758,6 +758,39 @@ func (h AdminApisHandler) getApplicationLoginSessions(l *logs.Log, r *http.Reque
 	return l.HTTPResponseSuccessJSON(data)
 }
 
+func (h AdminApisHandler) getSessions(l *logs.Log, r *http.Request, claims *tokenauth.Claims) logs.HTTPResponse {
+	userRoleFromQuery := r.URL.Query().Get("user-role")
+	var userRole *string
+	if len(userRoleFromQuery) > 0 {
+		userRole = &userRoleFromQuery
+	}
+
+	startTimeFromQuery := r.URL.Query().Get("start")
+	var startTime *string
+	if len(startTimeFromQuery) > 0 {
+		startTime = &startTimeFromQuery
+	}
+
+	endTimeFromQuery := r.URL.Query().Get("start")
+	var endTime *string
+	if len(endTimeFromQuery) > 0 {
+		endTime = &endTimeFromQuery
+	}
+
+	getSessions, err := h.coreAPIs.Administration.AdmGetSessions(userRole, startTime, endTime)
+	if err != nil {
+		return l.HTTPResponseErrorAction("error finding login sessions", model.TypeLoginSession, nil, err, http.StatusInternalServerError, true)
+	}
+
+	//loginSessions := loginSessionsToDef(getLoginSessions)
+
+	data, err := json.Marshal(getSessions)
+	if err != nil {
+		return l.HTTPResponseErrorAction(logutils.ActionMarshal, model.TypeLoginSession, nil, err, http.StatusInternalServerError, false)
+	}
+	return l.HTTPResponseSuccessJSON(data)
+}
+
 func (h AdminApisHandler) getApplicationConfigs(l *logs.Log, r *http.Request, claims *tokenauth.Claims) logs.HTTPResponse {
 	appTypeIdentifier := r.URL.Query().Get("app_type_id")
 	if appTypeIdentifier == "" {

--- a/driver/web/authorization_admin_policy.csv
+++ b/driver/web/authorization_admin_policy.csv
@@ -47,7 +47,7 @@ p, all_accounts, /core/admin/application/permissions, (GET),
 p, all_accounts, /core/admin/application/roles, (GET),
 p, all_accounts, /core/admin/application/groups, (GET),
 p, get_accounts, /core/admin/application/accounts, (GET), Get accounts
-p, get_accounts, /core/admin/sessions, (GET), Get accounts
+p, get_accounts, /core/admin/sessions, (GET), Get sessions
 p, create_accounts, /core/admin/application/accounts, (POST), Create new account
 p, create_accounts, /core/admin/v2/application/accounts, (POST), Create new accounts
 p, create_accounts, /core/admin/application/permissions, (GET),

--- a/driver/web/authorization_admin_policy.csv
+++ b/driver/web/authorization_admin_policy.csv
@@ -47,6 +47,7 @@ p, all_accounts, /core/admin/application/permissions, (GET),
 p, all_accounts, /core/admin/application/roles, (GET),
 p, all_accounts, /core/admin/application/groups, (GET),
 p, get_accounts, /core/admin/application/accounts, (GET), Get accounts
+p, get_accounts, /core/admin/sessions, (GET), Get accounts
 p, create_accounts, /core/admin/application/accounts, (POST), Create new account
 p, create_accounts, /core/admin/v2/application/accounts, (POST), Create new accounts
 p, create_accounts, /core/admin/application/permissions, (GET),

--- a/driver/web/conversions_auth.go
+++ b/driver/web/conversions_auth.go
@@ -65,6 +65,54 @@ func loginSessionsToDef(items []model.LoginSession) []Def.LoginSession {
 	return result
 }
 
+// Session
+func sessionToDef(item model.Sessions) Def.Sessions {
+	//external ids
+	externalIds := map[string]interface{}{}
+	if item.ExternalIDs != nil {
+		for k, v := range *item.ExternalIDs {
+			externalIds[k] = v
+		}
+	}
+	//last login date
+	lastLoginDate := utils.FormatTime(&item.LastLoginDate)
+
+	//user role
+	var userRole *string
+	if item.UserRole != nil {
+		userRole = item.UserRole
+	}
+
+	//first name
+	var firstName *string
+	if item.FirstName != nil {
+		firstName = item.FirstName
+	}
+
+	//last name
+	var lastName *string
+	if item.LastName != nil {
+		lastName = item.LastName
+	}
+
+	//email
+	var email *string
+	if item.Email != nil {
+		email = item.Email
+	}
+
+	return Def.Sessions{UserRole: userRole, FirstName: firstName, LastName: lastName,
+		Email: email, ExternalIds: &externalIds, LastLoginDate: &lastLoginDate, Anonymous: item.Anonymous}
+}
+
+func sessionsToDef(items []model.Sessions) []Def.Sessions {
+	result := make([]Def.Sessions, len(items))
+	for i, item := range items {
+		result[i] = sessionToDef(item)
+	}
+	return result
+}
+
 func pubKeyFromDef(item *Def.PubKey) *keys.PubKey {
 	if item == nil {
 		return nil

--- a/driver/web/docs/gen/def.yaml
+++ b/driver/web/docs/gen/def.yaml
@@ -3682,6 +3682,59 @@ paths:
           description: Unauthorized
         '500':
           description: Internal error
+  /admin/application/sessions:
+    get:
+      tags:
+        - Admin
+      summary: Get user account
+      description: |
+        Get the user account
+
+        **Auth:** Requires admin access token
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: user-role
+          in: query
+          description: user role
+          required: false
+          style: form
+          explode: false
+          schema:
+            type: string
+        - name: start
+          in: query
+          description: 'The start time for filtering results, specified as a Unix timestamp in seconds'
+          required: false
+          style: form
+          explode: false
+          schema:
+            type: integer
+            format: int64
+        - name: end
+          in: query
+          description: 'The end time for filtering results, specified as a Unix timestamp in seconds'
+          required: false
+          style: form
+          explode: false
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Sessions'
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '500':
+          description: Internal error
   '/admin/application/roles/{id}':
     put:
       tags:
@@ -7371,6 +7424,25 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/LoginSession'
+    Sessions:
+      required:
+        - id
+      type: object
+      properties:
+        user_role:
+          type: string
+          nullable: true
+        first_name:
+          type: string
+          nullable: true
+        last_name:
+          type: string
+          nullable: true
+        external_ids:
+          type: object
+          nullable: true
+        last_login_date:
+          type: string
     _shared_req_Login:
       required:
         - auth_type

--- a/driver/web/docs/gen/def.yaml
+++ b/driver/web/docs/gen/def.yaml
@@ -3686,9 +3686,9 @@ paths:
     get:
       tags:
         - Admin
-      summary: Get user account
+      summary: Get sessions
       description: |
-        Get the user account
+        Get sessions
 
         **Auth:** Requires admin access token
       security:
@@ -3730,7 +3730,7 @@ paths:
             type: boolean
       responses:
         '200':
-          description: Success
+          description: Successful operation
           content:
             application/json:
               schema:
@@ -7433,8 +7433,6 @@ components:
           items:
             $ref: '#/components/schemas/LoginSession'
     Sessions:
-      required:
-        - id
       type: object
       properties:
         user_role:

--- a/driver/web/docs/gen/def.yaml
+++ b/driver/web/docs/gen/def.yaml
@@ -7441,6 +7441,9 @@ components:
         email:
           type: string
           nullable: true
+        anonymous:
+          type: boolean
+          nullable: true
         external_ids:
           type: object
           nullable: true

--- a/driver/web/docs/gen/def.yaml
+++ b/driver/web/docs/gen/def.yaml
@@ -3720,6 +3720,14 @@ paths:
           schema:
             type: integer
             format: int64
+        - name: anonymous
+          in: query
+          description: anonymous
+          required: false
+          style: form
+          explode: false
+          schema:
+            type: boolean
       responses:
         '200':
           description: Success

--- a/driver/web/docs/gen/def.yaml
+++ b/driver/web/docs/gen/def.yaml
@@ -7438,6 +7438,9 @@ components:
         last_name:
           type: string
           nullable: true
+        email:
+          type: string
+          nullable: true
         external_ids:
           type: object
           nullable: true

--- a/driver/web/docs/gen/gen_types.go
+++ b/driver/web/docs/gen/gen_types.go
@@ -700,6 +700,7 @@ type ServiceScope struct {
 
 // Sessions defines model for Sessions.
 type Sessions struct {
+	Anonymous     *bool                   `json:"anonymous"`
 	Email         *string                 `json:"email"`
 	ExternalIds   *map[string]interface{} `json:"external_ids"`
 	FirstName     *string                 `json:"first_name"`
@@ -1384,6 +1385,9 @@ type GetAdminApplicationSessionsParams struct {
 
 	// End The end time for filtering results, specified as a Unix timestamp in seconds
 	End *int64 `form:"end,omitempty" json:"end,omitempty"`
+
+	// Anonymous anonymous
+	Anonymous *bool `form:"anonymous,omitempty" json:"anonymous,omitempty"`
 }
 
 // GetAdminAuthAppTokenParams defines parameters for GetAdminAuthAppToken.

--- a/driver/web/docs/gen/gen_types.go
+++ b/driver/web/docs/gen/gen_types.go
@@ -698,6 +698,15 @@ type ServiceScope struct {
 	Scope       string  `json:"scope"`
 }
 
+// Sessions defines model for Sessions.
+type Sessions struct {
+	ExternalIds   *map[string]interface{} `json:"external_ids"`
+	FirstName     *string                 `json:"first_name"`
+	LastLoginDate *string                 `json:"last_login_date,omitempty"`
+	LastName      *string                 `json:"last_name"`
+	UserRole      *string                 `json:"user_role"`
+}
+
 // SupportedAuthType defines model for SupportedAuthType.
 type SupportedAuthType struct {
 	AuthTypeId *string                 `json:"auth_type_id,omitempty"`
@@ -1302,6 +1311,9 @@ type GetAdminApplicationAccountsParams struct {
 	// RoleIds A comma-separated list of role IDs
 	RoleIds *string `form:"role-ids,omitempty" json:"role-ids,omitempty"`
 
+	// UserRole The user role
+	UserRole *string `form:"user-role,omitempty" json:"user-role,omitempty"`
+
 	// GroupIds A comma-separated list of group IDs
 	GroupIds *string `form:"group-ids,omitempty" json:"group-ids,omitempty"`
 }
@@ -1359,6 +1371,18 @@ type GetAdminApplicationLoginSessionsParams struct {
 
 	// IpAddress ip address
 	IpAddress *string `form:"ip-address,omitempty" json:"ip-address,omitempty"`
+}
+
+// GetAdminApplicationSessionsParams defines parameters for GetAdminApplicationSessions.
+type GetAdminApplicationSessionsParams struct {
+	// UserRole user role
+	UserRole *string `form:"user-role,omitempty" json:"user-role,omitempty"`
+
+	// Start The start time for filtering results, specified as a Unix timestamp in seconds
+	Start *int64 `form:"start,omitempty" json:"start,omitempty"`
+
+	// End The end time for filtering results, specified as a Unix timestamp in seconds
+	End *int64 `form:"end,omitempty" json:"end,omitempty"`
 }
 
 // GetAdminAuthAppTokenParams defines parameters for GetAdminAuthAppToken.

--- a/driver/web/docs/gen/gen_types.go
+++ b/driver/web/docs/gen/gen_types.go
@@ -700,6 +700,7 @@ type ServiceScope struct {
 
 // Sessions defines model for Sessions.
 type Sessions struct {
+	Email         *string                 `json:"email"`
 	ExternalIds   *map[string]interface{} `json:"external_ids"`
 	FirstName     *string                 `json:"first_name"`
 	LastLoginDate *string                 `json:"last_login_date,omitempty"`

--- a/driver/web/docs/index.yaml
+++ b/driver/web/docs/index.yaml
@@ -159,6 +159,8 @@ paths:
     $ref: "./resources/admin/application/permissions.yaml"
   /admin/application/roles:
     $ref: "./resources/admin/application/roles.yaml"
+  /admin/application/sessions:
+    $ref: "./resources/admin/application/sessions.yaml"  
   /admin/application/roles/{id}:
     $ref: "./resources/admin/application/rolesID.yaml"
   /admin/application/roles/{id}/permissions:

--- a/driver/web/docs/resources/admin/application/sessions.yaml
+++ b/driver/web/docs/resources/admin/application/sessions.yaml
@@ -1,9 +1,9 @@
 get:
   tags:
   - Admin
-  summary: Get user account
+  summary: Get sessions
   description: |
-    Get the user account
+    Get sessions
 
     **Auth:** Requires admin access token
   security:
@@ -45,7 +45,7 @@ get:
         type: boolean
   responses:
     200:
-      description: Success
+      description: Successful operation
       content:
         application/json:
           schema:

--- a/driver/web/docs/resources/admin/application/sessions.yaml
+++ b/driver/web/docs/resources/admin/application/sessions.yaml
@@ -34,7 +34,15 @@ get:
       explode: false
       schema:
         type: integer
-        format: int64        
+        format: int64      
+    - name: anonymous
+      in: query
+      description: anonymous
+      required: false
+      style: form
+      explode: false
+      schema:
+        type: boolean
   responses:
     200:
       description: Success

--- a/driver/web/docs/resources/admin/application/sessions.yaml
+++ b/driver/web/docs/resources/admin/application/sessions.yaml
@@ -1,0 +1,52 @@
+get:
+  tags:
+  - Admin
+  summary: Get user account
+  description: |
+    Get the user account
+
+    **Auth:** Requires admin access token
+  security:
+    - bearerAuth: []
+  parameters:
+    - name: user-role
+      in: query
+      description: user role
+      required: false
+      style: form
+      explode: false
+      schema:
+        type: string  
+    - name: start
+      in: query
+      description: The start time for filtering results, specified as a Unix timestamp in seconds
+      required: false
+      style: form
+      explode: false
+      schema:
+        type: integer
+        format: int64  
+    - name: end
+      in: query
+      description: The end time for filtering results, specified as a Unix timestamp in seconds
+      required: false
+      style: form
+      explode: false
+      schema:
+        type: integer
+        format: int64        
+  responses:
+    200:
+      description: Success
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: "../../../schemas/user/Sessions.yaml"
+    400:
+      description: Bad request
+    401:
+      description: Unauthorized
+    500:
+      description: Internal error

--- a/driver/web/docs/schemas/index.yaml
+++ b/driver/web/docs/schemas/index.yaml
@@ -108,6 +108,8 @@ Follow:
   $ref: "./user/Follow.yaml"
 UserData:
   $ref: "./user/UserData.yaml"  
+Sessions:
+  $ref: "./user/Sessions.yaml"    
 
 ##### APIs requests and responses - they are at bottom
 

--- a/driver/web/docs/schemas/user/Sessions.yaml
+++ b/driver/web/docs/schemas/user/Sessions.yaml
@@ -1,0 +1,19 @@
+required:
+  - id
+type: object
+properties:
+  user_role:
+    type: string
+    nullable: true
+  first_name:
+    type: string
+    nullable: true  
+  last_name:
+    type: string
+    nullable: true  
+  external_ids:
+    type: object
+    nullable: true
+  last_login_date:
+    type: string
+ 

--- a/driver/web/docs/schemas/user/Sessions.yaml
+++ b/driver/web/docs/schemas/user/Sessions.yaml
@@ -11,6 +11,9 @@ properties:
   last_name:
     type: string
     nullable: true  
+  email:
+    type: string
+    nullable: true    
   external_ids:
     type: object
     nullable: true

--- a/driver/web/docs/schemas/user/Sessions.yaml
+++ b/driver/web/docs/schemas/user/Sessions.yaml
@@ -1,5 +1,3 @@
-required:
-  - id
 type: object
 properties:
   user_role:

--- a/driver/web/docs/schemas/user/Sessions.yaml
+++ b/driver/web/docs/schemas/user/Sessions.yaml
@@ -13,6 +13,9 @@ properties:
     nullable: true  
   email:
     type: string
+    nullable: true   
+  anonymous:
+    type: boolean
     nullable: true    
   external_ids:
     type: object


### PR DESCRIPTION
## Description
Please, provide an admin API for filtering accounts which are signed in in a specific date-time range.

The filter should contain at least 3 optional fields:

user_role (the same like in the get accounts API: https://api-dev.rokwire.illinois.edu/core/doc/ui/index.html#/Admin/get_admin_application_accounts)
start date time
end date time
anonymous
user_role
The result should include the user account as well as its NetID, UIN, email, First and Last names

Additional context
Source: https://github.com/rokwire/illinois_admin/issues/742#issuecomment-3137176802

**Resolves #789 

## Review Time Estimate

- [ ] Immediately
- [ ] Within a week
- [x] When possible

## Type of changes
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Other (any another change that does not fall in one of the above categories.)

## Checklist:
- [x] I have signed the Rokwire Contributor License Agreement ([CLA](https://rokwire.org/rokwire_cla)). (_Any contributor who is not an employee of the University of Illinois whose official duties include contributing to the Rokwire software, or who is not paid by the Rokwire project, needs to sign the CLA before their contribution can be accepted._)
- [x] I have updated the [CHANGELOG](../CHANGELOG.md).
- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] My change requires updating the documentation.
- [x] I have made necessary changes to the documentation.
- [ ] I have added tests related to my changes.
- [ ] My changes generate no new warnings.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
